### PR TITLE
Fix: Switch reqwest TLS backend to Rustls to resolve connection errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +352,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -681,8 +697,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -692,8 +710,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
+ "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 
@@ -879,6 +899,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -1183,6 +1204,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1337,7 +1364,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
- "rand",
+ "rand 0.8.5",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -1381,7 +1408,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -1577,7 +1604,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1587,7 +1614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1670,6 +1697,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.1",
+ "lru-slab",
+ "rand 0.9.1",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1685,8 +1767,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1696,7 +1788,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1706,6 +1808,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.1",
 ]
 
 [[package]]
@@ -1799,11 +1910,9 @@ dependencies = [
  "async-compression",
  "base64",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -1819,14 +1928,18 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
  "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-service",
@@ -1859,6 +1972,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustix"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1878,10 +1997,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -1898,6 +2030,9 @@ name = "rustls-pki-types"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+dependencies = [
+ "web-time",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -1944,7 +2079,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2174,27 +2322,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2219,6 +2346,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2236,6 +2383,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -2414,7 +2576,6 @@ dependencies = [
  "mockito",
  "monolith",
  "num_cpus",
- "openssl",
  "rayon",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,11 +86,6 @@ version = "^2.10"
 features = []
 
 
-[dependencies.openssl]
-version = "0.10"
-features = ["vendored"]
-
-
 [dependencies.regex]
 version = "1.10"
 default-features = false
@@ -99,7 +94,8 @@ features = ["std", "perf-dfa", "unicode-perl"]
 
 [dependencies.reqwest]
 version = "0.12"
-features = ["default-tls", "gzip", "brotli", "deflate"]
+default-features = false
+features = ["rustls-tls-native-roots", "gzip", "brotli", "deflate"]
 
 
 [dependencies.tokio]

--- a/llms.txt
+++ b/llms.txt
@@ -53,7 +53,6 @@ The content is organized as follows:
     ci.yml
 issues/
   issue101.txt
-  issue102.txt
 src/
   cli.rs
   html.rs
@@ -331,2386 +330,6 @@ $END$
 ]
 </file>
 
-<file path="issues/issue102.txt">
-```
-./testdata/example.sh
-```
-
-which is
-
-```
-#!/usr/bin/env bash
-cd "$(dirname "$0")"
-
-echo "https://helpx.adobe.com/pl/indesign/using/using-fonts.html" | ../target/release/twars-url2md --stdin -o out
-
-```
-
-yields
-
-```
-2025-06-24T22:09:19.613518Z  INFO twars_url2md::cli: Reading URLs from stdin.
-2025-06-24T22:09:19.614579Z  INFO twars_url2md: Collected 1 URLs to process.
-2025-06-24T22:09:19.615073Z  INFO twars_url2md: Processing URL: https://helpx.adobe.com/pl/indesign/using/using-fonts.html
-2025-06-24T22:09:49.621694Z ERROR twars_url2md::html: HTTP request timed out for https://helpx.adobe.com/pl/indesign/using/using-fonts.html after 30 seconds
-2025-06-24T22:09:49.621761Z  WARN twars_url2md::html: Error fetching HTML from https://helpx.adobe.com/pl/indesign/using/using-fonts.html (get_markdown_for_url): Request timed out for URL: https://helpx.adobe.com/pl/indesign/using/using-fonts.html. Using fallback processing.
-2025-06-24T22:10:50.624652Z  INFO twars_url2md::html: Retrying https://helpx.adobe.com/pl/indesign/using/using-fonts.html (attempt 2/3)
-
-```
-
-but 
-
-```
-curl "https://helpx.adobe.com/pl/indesign/using/using-fonts.html"
-``` 
-
-works just fine
-</file>
-
-<file path="test_output/example.com/index.md">
-Example Domain
-
-# Example Domain
-
-This domain is for use in illustrative examples in documents. You may use this domain in literature without prior coordination or asking for permission.
-
-[More information...](https://www.iana.org/domains/example)
-</file>
-
-<file path="tests/integration/e2e_tests.rs">
-// this_file: tests/integration/e2e_tests.rs
-
-use anyhow::Result;
-use tempfile::TempDir;
-use twars_url2md::{process_urls, Config};
-
-#[cfg(test)]
-mod end_to_end_tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn test_single_url_processing() -> Result<()> {
-        let _m = mockito::mock("GET", "/simple.html")
-            .with_status(200)
-            .with_header("content-type", "text/html")
-            .with_body(r#"
-                <html>
-                    <body>
-                        <h1>Simple Page</h1>
-                        <p>This is a simple test page.</p>
-                    </body>
-                </html>
-            "#)
-            .create();
-
-        let temp_dir = TempDir::new()?;
-        let url = format!("{}/simple.html", mockito::server_url());
-        
-        let config = Config {
-            verbose: false,
-            max_retries: 3,
-            output_base: temp_dir.path().to_path_buf(),
-            single_file: false,
-            has_output: true,
-            pack_file: None,
-        };
-
-        let errors = process_urls(vec![url.clone()], config).await?;
-        assert!(errors.is_empty());
-
-        // Check that the file was created
-        let host = mockito::server_url().replace("http://", "");
-        let expected_path = temp_dir.path().join(&host).join("simple.md");
-        assert!(expected_path.exists());
-
-        // Check content
-        let content = tokio::fs::read_to_string(&expected_path).await?;
-        assert!(content.contains("Simple Page"));
-        assert!(content.contains("simple test page"));
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_multiple_urls_processing() -> Result<()> {
-        let _m1 = mockito::mock("GET", "/page1.html")
-            .with_status(200)
-            .with_header("content-type", "text/html")
-            .with_body("<html><body><h1>Page 1</h1></body></html>")
-            .create();
-
-        let _m2 = mockito::mock("GET", "/page2.html")
-            .with_status(200)
-            .with_header("content-type", "text/html")
-            .with_body("<html><body><h1>Page 2</h1></body></html>")
-            .create();
-
-        let _m3 = mockito::mock("GET", "/page3.html")
-            .with_status(200)
-            .with_header("content-type", "text/html")
-            .with_body("<html><body><h1>Page 3</h1></body></html>")
-            .create();
-
-        let temp_dir = TempDir::new()?;
-        let urls = vec![
-            format!("{}/page1.html", mockito::server_url()),
-            format!("{}/page2.html", mockito::server_url()),
-            format!("{}/page3.html", mockito::server_url()),
-        ];
-
-        let config = Config {
-            verbose: false,
-            max_retries: 3,
-            output_base: temp_dir.path().to_path_buf(),
-            single_file: false,
-            has_output: true,
-            pack_file: None,
-        };
-
-        let errors = process_urls(urls, config).await?;
-        assert!(errors.is_empty());
-
-        // Check all files were created
-        let host = mockito::server_url().replace("http://", "");
-        for i in 1..=3 {
-            let path = temp_dir.path().join(&host).join(format!("page{}.md", i));
-            assert!(path.exists());
-            let content = tokio::fs::read_to_string(&path).await?;
-            assert!(content.contains(&format!("Page {}", i)));
-        }
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_packed_output() -> Result<()> {
-        let _m1 = mockito::mock("GET", "/doc1.html")
-            .with_status(200)
-            .with_header("content-type", "text/html")
-            .with_body("<html><body><h1>Document 1</h1><p>Content 1</p></body></html>")
-            .create();
-
-        let _m2 = mockito::mock("GET", "/doc2.html")
-            .with_status(200)
-            .with_header("content-type", "text/html")
-            .with_body("<html><body><h1>Document 2</h1><p>Content 2</p></body></html>")
-            .create();
-
-        let temp_dir = TempDir::new()?;
-        let pack_file = temp_dir.path().join("packed.md");
-        let urls = vec![
-            format!("{}/doc1.html", mockito::server_url()),
-            format!("{}/doc2.html", mockito::server_url()),
-        ];
-
-        let config = Config {
-            verbose: false,
-            max_retries: 3,
-            output_base: temp_dir.path().to_path_buf(),
-            single_file: false,
-            has_output: true,
-            pack_file: Some(pack_file.clone()),
-        };
-
-        let errors = process_urls(urls, config).await?;
-        assert!(errors.is_empty());
-
-        // Check packed file exists and contains both documents
-        assert!(pack_file.exists());
-        let content = tokio::fs::read_to_string(&pack_file).await?;
-        assert!(content.contains("Document 1"));
-        assert!(content.contains("Content 1"));
-        assert!(content.contains("Document 2"));
-        assert!(content.contains("Content 2"));
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_error_handling() -> Result<()> {
-        let _m = mockito::mock("GET", "/error.html")
-            .with_status(500)
-            .with_body("Internal Server Error")
-            .expect(4) // Initial try + 3 retries
-            .create();
-
-        let temp_dir = TempDir::new()?;
-        let url = format!("{}/error.html", mockito::server_url());
-
-        let config = Config {
-            verbose: false,
-            max_retries: 3,
-            output_base: temp_dir.path().to_path_buf(),
-            single_file: false,
-            has_output: true,
-            pack_file: None,
-        };
-
-        let errors = process_urls(vec![url.clone()], config).await?;
-        assert_eq!(errors.len(), 1);
-        assert_eq!(errors[0].0, url);
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_mixed_success_and_failure() -> Result<()> {
-        let _m1 = mockito::mock("GET", "/success.html")
-            .with_status(200)
-            .with_header("content-type", "text/html")
-            .with_body("<html><body><h1>Success</h1></body></html>")
-            .create();
-
-        let _m2 = mockito::mock("GET", "/failure.html")
-            .with_status(404)
-            .expect(4) // Initial try + 3 retries
-            .create();
-
-        let temp_dir = TempDir::new()?;
-        let urls = vec![
-            format!("{}/success.html", mockito::server_url()),
-            format!("{}/failure.html", mockito::server_url()),
-        ];
-
-        let config = Config {
-            verbose: false,
-            max_retries: 3,
-            output_base: temp_dir.path().to_path_buf(),
-            single_file: false,
-            has_output: true,
-            pack_file: None,
-        };
-
-        let errors = process_urls(urls.clone(), config).await?;
-        assert_eq!(errors.len(), 1);
-        assert!(errors[0].0.contains("failure.html"));
-
-        // Success file should exist
-        let host = mockito::server_url().replace("http://", "");
-        let success_path = temp_dir.path().join(&host).join("success.md");
-        assert!(success_path.exists());
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_single_file_output() -> Result<()> {
-        let _m = mockito::mock("GET", "/content.html")
-            .with_status(200)
-            .with_header("content-type", "text/html")
-            .with_body("<html><body><h1>Content</h1></body></html>")
-            .create();
-
-        let temp_dir = TempDir::new()?;
-        let output_file = temp_dir.path().join("output.md");
-        let url = format!("{}/content.html", mockito::server_url());
-
-        let config = Config {
-            verbose: false,
-            max_retries: 3,
-            output_base: output_file.clone(),
-            single_file: true,
-            has_output: true,
-            pack_file: None,
-        };
-
-        let errors = process_urls(vec![url], config).await?;
-        assert!(errors.is_empty());
-
-        // Check file was created at specified path
-        assert!(output_file.exists());
-        let content = tokio::fs::read_to_string(&output_file).await?;
-        assert!(content.contains("Content"));
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_non_html_content_skipped() -> Result<()> {
-        let urls = vec![
-            "https://example.com/image.jpg".to_string(),
-            "https://example.com/document.pdf".to_string(),
-            "https://example.com/video.mp4".to_string(),
-        ];
-
-        let temp_dir = TempDir::new()?;
-        let config = Config {
-            verbose: false,
-            max_retries: 3,
-            output_base: temp_dir.path().to_path_buf(),
-            single_file: false,
-            has_output: true,
-            pack_file: None,
-        };
-
-        // These should be skipped without errors
-        let _errors = process_urls(urls, config).await?;
-        
-        // No files should be created for non-HTML content
-        assert!(temp_dir.path().read_dir()?.next().is_none());
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_local_file_processing() -> Result<()> {
-        let temp_dir = TempDir::new()?;
-        let html_file = temp_dir.path().join("local.html");
-        tokio::fs::write(&html_file, "<html><body><h1>Local File</h1></body></html>").await?;
-
-        let url = format!("file://{}", html_file.display());
-        let output_dir = temp_dir.path().join("output");
-
-        let config = Config {
-            verbose: false,
-            max_retries: 3,
-            output_base: output_dir.clone(),
-            single_file: false,
-            has_output: true,
-            pack_file: None,
-        };
-
-        let errors = process_urls(vec![url], config).await?;
-        assert!(errors.is_empty());
-
-        // Check output was created
-        let output_files: Vec<_> = std::fs::read_dir(&output_dir)?
-            .filter_map(|e| e.ok())
-            .collect();
-        assert!(!output_files.is_empty());
-
-        Ok(())
-    }
-}
-</file>
-
-<file path="tests/integration/mod.rs">
-// this_file: tests/integration/mod.rs
-
-pub mod e2e_tests;
-</file>
-
-<file path="tests/unit/mod.rs">
-// this_file: tests/unit/mod.rs
-
-pub mod url_tests;
-</file>
-
-<file path="tests/tests.rs">
-// this_file: tests/tests.rs
-
-mod unit;
-// mod integration; // Temporarily disabled due to mockito version incompatibility
-</file>
-
-<file path="AGENTS.md">
-# https://github.com/twardoch/twars-url2md
-
-## 1. Project Overview
-
-`twars-url2md` is a Rust CLI application that downloads URLs and converts them to clean, readable Markdown files. It can extract URLs from various text formats and process them concurrently.
-
-## 2. Commands
-
-### 2.1. Development
-```bash
-# Run tests
-cargo test --all-features
-
-# Format code
-cargo fmt
-
-# Run linter
-cargo clippy --all-targets --all-features
-
-# Build release binary
-cargo build --release
-
-# Run with arguments
-cargo run -- [OPTIONS]
-```
-
-### 2.2. Publishing
-```bash
-# Verify package before publishing
-cargo package
-
-# Publish to crates.io
-cargo publish
-```
-
-## 3. Architecture
-
-The codebase follows a modular design with clear separation of concerns:
-
-- `src/main.rs` - Entry point with panic handling wrapper
-- `src/lib.rs` - Core processing logic and orchestration
-- `src/cli.rs` - Command-line interface using Clap
-- `src/url.rs` - URL extraction and validation logic
-- `src/html.rs` - HTML fetching and cleaning using Monolith
-- `src/markdown.rs` - HTML to Markdown conversion using htmd
-
-### 3.1. Key Design Decisions
-
-1. **Panic Recovery**: The application catches panics from the Monolith library to prevent crashes during HTML processing (see `src/main.rs:10-20`).
-
-2. **Concurrent Processing**: Uses Tokio with adaptive concurrency based on available CPUs for parallel URL processing (see `src/lib.rs:107-120`).
-
-3. **Error Handling**: Uses `anyhow` for error propagation with custom error types and retry logic for network failures.
-
-4. **Output Organization**: Generates file paths based on URL structure when using `-o` option, creating a repository-like structure.
-
-## 4. Testing
-
-Run tests with `cargo test --all-features`. The test module is in `src/tests.rs` and includes unit tests for URL extraction and processing logic.
-
-## 5. Dependencies
-
-- **Async Runtime**: tokio with full features
-- **HTTP Client**: reqwest with vendored OpenSSL
-- **HTML Processing**: monolith for cleaning, htmd for Markdown conversion
-- **CLI**: clap with derive feature
-- **Utilities**: indicatif (progress bars), rayon (parallelism)
-
-## 6. Active Development
-
-See `TODO.md` for the modernization plan, which includes:
-- Migration from OpenSSL to rustls
-- Integration of structured logging with tracing
-- Enhanced error reporting
-- Performance optimizations
-
-When implementing new features, ensure compatibility with the async architecture and maintain the modular structure.
-
-# Working principles for software development
-
-## 7. When you write code (in any language)
-
-- Iterate gradually, avoiding major changes 
-- Minimize confirmations and checks
-- Preserve existing code/structure unless necessary
-- Use constants over magic numbers
-- Check for existing solutions in the codebase before starting
-- Check often the coherence of the code you’re writing with the rest of the code. 
-- Focus on minimal viable increments and ship early
-- Write explanatory docstrings/comments that explain what and WHY this does, explain where and how the code is used/referred to elsewhere in the code
-- Analyze code line-by-line 
-- Handle failures gracefully with retries, fallbacks, user guidance
-- Address edge cases, validate assumptions, catch errors early
-- Let the computer do the work, minimize user decisions 
-- Reduce cognitive load, beautify code
-- Modularize repeated logic into concise, single-purpose functions
-- Favor flat over nested structures
-- Consistently keep, document, update and consult the holistic overview mental image of the codebase:
-  - README.md (purpose and functionality) 
-  - CHANGELOG.md (past changes)
-  - TODO.md (future goals)
-  - PROGRESS.md (detailed flat task list)
-
-## 8. Use MCP tools if you can
-
-Before and during coding (if have access to tools), you should: 
-
-- consult the `context7` tool for most up-to-date software package documentation;
-- ask intelligent questions to the `deepseek/deepseek-r1-0528:free` model via the `chat_completion` tool to get additional reasoning;
-- also consult the `openai/o3` model via the `chat_completion` tool for additional reasoning and help with the task;
-- use the `sequentialthinking` tool to think about the best way to solve the task; 
-- use the `perplexity_ask` and `duckduckgo_web_search` tools to gather up-to-date information or context;
-
-## 9. Keep track of paths
-
-In each source file, maintain the up-to-date `this_file` record that shows the path of the current file relative to project root. Place the `this_file` record near the top of the file, as a comment after the shebangs, or in the YAML Markdown frontmatter. 
-
-## 10. If you write Python
-
-- PEP 8: Use consistent formatting and naming
-- Write clear, descriptive names for functions and variables
-- PEP 20: Keep code simple and explicit. Prioritize readability over cleverness
-- Use type hints in their simplest form (list, dict, | for unions)
-- PEP 257: Write clear, imperative docstrings
-- Use f-strings. Use structural pattern matching where appropriate
-- ALWAYS add "verbose" mode logugu-based logging, & debug-log
-- For CLI Python scripts, use fire & rich, and start the script with 
-
-```
-#!/usr/bin/env -S uv run -s
-# /// script
-# dependencies = ["PKG1", "PKG2"]
-# ///
-# this_file: PATH_TO_CURRENT_FILE
-```
-
-After Python changes run:
-
-```
-uzpy run .; fd -e py -x autoflake {}; fd -e py -x pyupgrade --py312-plus {}; fd -e py -x ruff check --output-format=github --fix --unsafe-fixes {}; fd -e py -x ruff format --respect-gitignore --target-version py312 {}; python -m pytest;
-```
-
-## 11. Additional guidelines
-
-Ask before extending/refactoring existing code in a way that may add complexity or break things. 
-
-When you’re finished, print "Wait, but" to go back, think & reflect, revise & improvement what you’ve done (but don’t invent functionality freely). Repeat this. But stick to the goal of "minimal viable next version". 
-
-## 12. Virtual team work
-
-Be creative, diligent, critical, relentless & funny! Lead two experts: "Ideot" for creative, unorthodox ideas, and "Critin" to critique flawed thinking and moderate for balanced discussions. The three of you shall illuminate knowledge with concise, beautiful responses, process methodically for clear answers, collaborate step-by-step, sharing thoughts and adapting. If errors are found, step back and focus on accuracy and progress.
-
-## 13. Development Guidelines
-
-- Only modify code directly relevant to the specific request. Avoid changing unrelated functionality.
-- Never replace code with placeholders like `# ... rest of the processing ...`. Always include complete code.
-- Break problems into smaller steps. Think through each step separately before implementing.
-- Always provide a complete PLAN with REASONING based on evidence from code and logs before making changes.
-- Explain your OBSERVATIONS clearly, then provide REASONING to identify the exact issue. Add console logs when needed to gather more information.
-
-
-The URL-to-markdown conversion system consists of three primary business components:
-
-### 13.1. URL Processing and Content Extraction (Importance: 95)
-- Collects URLs from multiple input sources (stdin, files)
-- Validates and resolves URLs against base URLs when needed
-- Implements a robust retry mechanism for handling transient network failures
-- Processes URLs concurrently with dynamic CPU core adaptation
-- Located in `src/cli.rs` and `src/url.rs`
-
-### 13.2. HTML Processing Pipeline (Importance: 90)
-- Fetches HTML content using Monolith for specialized content extraction
-- Implements fallback mechanisms for non-HTML content
-- Handles custom HTML processing with configurable options
-- Transforms complex HTML structures into clean markdown
-- Located in `src/html.rs`
-
-### 13.3. Content Organization and Output Management (Importance: 85)
-- Creates structured output paths mirroring URL hierarchies
-- Supports packing mode for combining multiple URLs into single documents
-- Maintains original URL ordering in packed output
-- Handles both remote URLs and local file paths consistently
-- Located in `src/lib.rs` and `src/markdown.rs`
-
-### 13.4. Integration Points
-
-The system connects these components through:
-
-1. URL Collection -> HTML Processing
-- URLs are validated and normalized before processing
-- Concurrent processing queue manages HTML fetching
-- Retry logic handles failed attempts
-
-2. HTML Processing -> Content Organization
-- Processed HTML is transformed to markdown
-- Output paths are generated based on URL structure
-- Content is either packed or distributed based on mode
-
-The build system embeds version and build metadata for traceability, ensuring each deployment can be traced to its source state.
-
-To read the full codebase, run `npx repomix -o llms.txt .` and then read `llms.txt`
-
-$END$
-</file>
-
-<file path="LICENSE">
-MIT License
-
-Copyright (c) 2025 Adam Twardoch
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-</file>
-
-<file path="test_http.rs">
-use reqwest;
-use std::time::Duration;
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let client = reqwest::Client::builder()
-        .user_agent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
-        .timeout(Duration::from_secs(10))
-        .build()?;
-    
-    println!("Fetching URL...");
-    let response = client
-        .get("https://helpx.adobe.com/pl/indesign/using/using-fonts.html")
-        .send()
-        .await?;
-    
-    println!("Status: {}", response.status());
-    println!("Content-Type: {:?}", response.headers().get("content-type"));
-    
-    let text = response.text().await?;
-    println!("Response length: {} bytes", text.len());
-    
-    Ok(())
-}
-</file>
-
-<file path="test_output2">
-Example Domain
-
-# Example Domain
-
-This domain is for use in illustrative examples in documents. You may use this domain in literature without prior coordination or asking for permission.
-
-[More information...](https://www.iana.org/domains/example)
-</file>
-
-<file path="test_urls.txt">
-https://example.com
-</file>
-
-<file path="TESTS.md">
-# Comprehensive Test Plan for twars-url2md
-
-## Overview
-
-This document outlines the comprehensive test strategy for the `twars-url2md` project, a Rust CLI application that downloads URLs and converts them to clean, readable Markdown files. The test suite aims to ensure reliability, correctness, and robustness across all components.
-
-## Test Structure
-
-### 1. Unit Tests
-
-#### 1.1 URL Module (`src/url.rs`)
-- **URL Extraction**
-  - Extract URLs from plain text
-  - Extract URLs from Markdown links
-  - Extract URLs from HTML href attributes
-  - Handle mixed format inputs
-  - Handle URLs with special characters and encodings
-  - Test empty and malformed inputs
-
-- **URL Validation**
-  - Validate HTTP/HTTPS URLs
-  - Reject invalid protocols
-  - Handle relative URLs with base URL resolution
-  - Test URL normalization (trailing slashes, fragments)
-  - Handle internationalized domain names (IDN)
-
-- **URL Processing**
-  - Deduplicate URLs correctly
-  - Preserve URL ordering when required
-  - Handle query parameters and fragments appropriately
-
-#### 1.2 HTML Module (`src/html.rs`)
-- **HTML Fetching**
-  - Mock HTTP requests for different status codes (200, 404, 500, etc.)
-  - Test timeout handling
-  - Test redirect following (301, 302)
-  - Handle large HTML documents
-  - Test content-type validation
-
-- **Monolith Integration**
-  - Test HTML cleaning with various configurations
-  - Handle JavaScript-heavy pages
-  - Test CSS inlining behavior
-  - Verify image handling (base64 encoding vs. external)
-  - Test iframe and embedded content handling
-
-- **Error Recovery**
-  - Test panic recovery from Monolith crashes
-  - Verify fallback mechanisms for non-HTML content
-  - Test retry logic for transient failures
-
-#### 1.3 Markdown Module (`src/markdown.rs`)
-- **HTML to Markdown Conversion**
-  - Test basic HTML elements (p, div, span)
-  - Test headings (h1-h6) conversion
-  - Test list conversion (ul, ol, nested lists)
-  - Test link preservation
-  - Test image alt text and URLs
-  - Test code blocks and inline code
-  - Test table conversion
-  - Test blockquote handling
-  - Handle malformed HTML gracefully
-
-- **Content Cleaning**
-  - Remove script and style tags
-  - Preserve semantic structure
-  - Handle special characters and entities
-  - Test Unicode handling
-
-#### 1.4 CLI Module (`src/cli.rs`)
-- **Argument Parsing**
-  - Test all CLI flags and options
-  - Validate mutually exclusive options
-  - Test default values
-  - Verify help text accuracy
-  - Test argument validation and error messages
-
-- **Input Handling**
-  - Read from stdin
-  - Read from files
-  - Handle multiple input sources
-  - Test glob pattern expansion
-  - Handle non-existent files gracefully
-
-#### 1.5 Library Module (`src/lib.rs`)
-- **Orchestration Logic**
-  - Test sequential vs. concurrent processing modes
-  - Verify CPU core detection and adaptation
-  - Test progress reporting
-  - Verify output organization logic
-
-- **Path Generation**
-  - Test URL-to-filesystem path conversion
-  - Handle special characters in paths
-  - Test collision handling
-  - Verify directory creation
-  - Test both flat and hierarchical output modes
-
-### 2. Integration Tests
-
-#### 2.1 End-to-End Workflows
-- **Single URL Processing**
-  - Download and convert a simple HTML page
-  - Process a complex web page with images and styles
-  - Handle a non-HTML resource (PDF, image)
-  - Test local file processing
-
-- **Batch Processing**
-  - Process multiple URLs from a file
-  - Test concurrent processing limits
-  - Verify output file organization
-  - Test packed mode output
-
-- **Error Scenarios**
-  - Network timeouts
-  - Invalid URLs
-  - Server errors
-  - Disk write failures
-  - Insufficient permissions
-
-#### 2.2 Monolith Integration
-- Test full Monolith pipeline with real HTML
-- Verify CSS and JavaScript handling
-- Test resource embedding options
-- Confirm panic recovery in real scenarios
-
-### 3. Performance Tests
-
-#### 3.1 Concurrency Testing
-- **Load Testing**
-  - Process 100+ URLs concurrently
-  - Measure memory usage under load
-  - Test connection pool limits
-  - Verify rate limiting behavior
-
-- **Resource Management**
-  - Test file descriptor limits
-  - Monitor thread pool usage
-  - Verify cleanup of temporary resources
-
-#### 3.2 Benchmarks
-- Benchmark URL extraction performance
-- Benchmark HTML to Markdown conversion
-- Measure overhead of concurrent processing
-- Profile memory allocation patterns
-
-### 4. Property-Based Tests
-
-Using `proptest` or similar:
-- Generate random URL patterns
-- Test with arbitrary HTML structures
-- Fuzz input parsing
-- Verify invariants hold under random inputs
-
-### 5. Regression Tests
-
-- Specific test cases for reported bugs
-- Edge cases discovered in production
-- Platform-specific issues (Windows paths, etc.)
-
-## Test Data and Fixtures
-
-### Mock Data
-- Sample HTML files of varying complexity
-- Mock HTTP responses for different scenarios
-- Test URLs covering various patterns
-- Malformed inputs for error testing
-
-### Test Servers
-- Mock HTTP server for integration tests
-- Configurable response delays
-- Error injection capabilities
-- Redirect chain testing
-
-## Testing Infrastructure
-
-### Continuous Integration
-- Run full test suite on PR
-- Platform matrix (Linux, macOS, Windows)
-- Rust version compatibility testing
-- Dependency audit
-
-### Code Coverage
-- Target: 80% line coverage minimum
-- 100% coverage for critical paths
-- Coverage reports in CI
-
-### Test Organization
-```
-tests/
-├── unit/
-│   ├── url_tests.rs
-│   ├── html_tests.rs
-│   ├── markdown_tests.rs
-│   └── cli_tests.rs
-├── integration/
-│   ├── e2e_tests.rs
-│   ├── monolith_tests.rs
-│   └── concurrent_tests.rs
-├── fixtures/
-│   ├── html/
-│   ├── urls/
-│   └── expected/
-└── common/
-    ├── mod.rs
-    └── helpers.rs
-```
-
-## Testing Commands
-
-```bash
-# Run all tests
-cargo test --all-features
-
-# Run unit tests only
-cargo test --lib
-
-# Run integration tests
-cargo test --test '*'
-
-# Run with coverage
-cargo tarpaulin --out Html
-
-# Run benchmarks
-cargo bench
-
-# Run specific test module
-cargo test url::tests
-
-# Run tests with logging
-RUST_LOG=debug cargo test -- --nocapture
-```
-
-## Test Implementation Priority
-
-1. **Phase 1: Core Functionality**
-   - URL extraction and validation
-   - Basic HTML to Markdown conversion
-   - CLI argument parsing
-
-2. **Phase 2: Integration**
-   - End-to-end workflows
-   - Monolith integration
-   - Error handling
-
-3. **Phase 3: Robustness**
-   - Concurrent processing
-   - Property-based tests
-   - Performance benchmarks
-
-4. **Phase 4: Polish**
-   - Platform-specific tests
-   - Regression test suite
-   - Documentation tests
-
-## Success Criteria
-
-- All tests pass in CI
-- No flaky tests
-- Test execution < 60 seconds
-- Clear test names and documentation
-- Easy to add new test cases
-- Comprehensive error scenario coverage
-</file>
-
-<file path="issues/issue101.txt">
-```
-twars-url2md -h
-```
-
-Nothing is printed. The usage help should be printed. 
-
----
-
-```
-twars-url2md
-```
-
-prints
-
-```
-Error: Either --stdin or --input must be specified
-Run with --help for usage information
-```
-
-Not much. Should be more extensive (basically same as `-h` output).
-
----
-
-```
-echo "https://helpx.adobe.com/pl/indesign/using/using-fonts.html" | twars-url2md --stdin
-```
-
-this prints 
-
-```
-2025-06-24T16:30:54.141096Z  INFO twars_url2md::cli: Reading URLs from stdin.
-2025-06-24T16:30:54.142688Z  INFO twars_url2md: Collected 1 URLs to process.
-2025-06-24T16:30:54.143531Z  INFO twars_url2md: Processing URL: https://helpx.adobe.com/pl/indesign/using/using-fonts.html
-```
-
-but then it stalls. It creates some subfolders (based on the domain URL structure) but that's it. 
-
-
-```
-echo "https://helpx.adobe.com/pl/indesign/using/using-fonts.html" | twars-url2md --stdin -p out.md
-```
-
-or 
-
-```
-echo "https://helpx.adobe.com/pl/indesign/using/using-fonts.html" | twars-url2md --stdin -o out
-```
-
-prints the `Processing URL:` etc. but then nothing gets written. 
-
-<task>
-Read `./README.md` to understand how the app should work. Then write into `./TODO.md` a detailed plan on how you want to fix the issues described above. 
-</task>
-</file>
-
-<file path="src/markdown.rs">
-use anyhow::{Context, Result};
-
-/// Convert HTML to Markdown
-pub fn convert_html_to_markdown(html: &str) -> Result<String> {
-    htmd::convert(html).context("Failed to convert HTML to Markdown")
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_convert_html_to_markdown() -> Result<()> {
-        let html = r#"
-            <html>
-                <body>
-                    <h1>Test</h1>
-                    <p>Hello, world!</p>
-                </body>
-            </html>
-        "#;
-
-        let markdown = convert_html_to_markdown(html)?;
-        assert!(markdown.contains("# Test"));
-        assert!(markdown.contains("Hello, world!"));
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_heading_levels() -> Result<()> {
-        let html = r#"
-            <h1>Level 1</h1>
-            <h2>Level 2</h2>
-            <h3>Level 3</h3>
-            <h4>Level 4</h4>
-            <h5>Level 5</h5>
-            <h6>Level 6</h6>
-        "#;
-
-        let markdown = convert_html_to_markdown(html)?;
-        assert!(markdown.contains("# Level 1"));
-        assert!(markdown.contains("## Level 2"));
-        assert!(markdown.contains("### Level 3"));
-        assert!(markdown.contains("#### Level 4"));
-        assert!(markdown.contains("##### Level 5"));
-        assert!(markdown.contains("###### Level 6"));
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_text_formatting() -> Result<()> {
-        let html = r#"
-            <p>Text with <strong>bold</strong> and <em>italic</em> and <code>code</code>.</p>
-            <p>Also <b>bold tag</b> and <i>italic tag</i>.</p>
-        "#;
-
-        let markdown = convert_html_to_markdown(html)?;
-        assert!(markdown.contains("**bold**"));
-        assert!(markdown.contains("*italic*") || markdown.contains("_italic_"));
-        assert!(markdown.contains("`code`"));
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_lists() -> Result<()> {
-        let html = r#"
-            <ul>
-                <li>Unordered 1</li>
-                <li>Unordered 2</li>
-            </ul>
-            <ol>
-                <li>Ordered 1</li>
-                <li>Ordered 2</li>
-            </ol>
-        "#;
-
-        let markdown = convert_html_to_markdown(html)?;
-        // htmd might use different list markers
-        assert!(markdown.contains("Unordered 1"));
-        assert!(markdown.contains("Unordered 2"));
-        assert!(markdown.contains("Ordered 1"));
-        assert!(markdown.contains("Ordered 2"));
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_links_and_images() -> Result<()> {
-        let html = r#"
-            <p>Visit <a href="https://example.com">Example Site</a>.</p>
-            <p><img src="test.jpg" alt="Test Image" /></p>
-        "#;
-
-        let markdown = convert_html_to_markdown(html)?;
-        assert!(markdown.contains("[Example Site](https://example.com)"));
-        assert!(markdown.contains("![Test Image](test.jpg)"));
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_blockquotes() -> Result<()> {
-        let html = r#"
-            <blockquote>
-                <p>This is a quote.</p>
-            </blockquote>
-        "#;
-
-        let markdown = convert_html_to_markdown(html)?;
-        assert!(markdown.contains("> This is a quote."));
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_code_blocks() -> Result<()> {
-        let html = r#"
-            <pre><code>fn main() {
-    println!("Hello");
-}</code></pre>
-        "#;
-
-        let markdown = convert_html_to_markdown(html)?;
-        assert!(markdown.contains("```") || markdown.contains("    fn main()"));
-        assert!(markdown.contains("println!"));
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_horizontal_rule() -> Result<()> {
-        let html = r#"
-            <p>Before</p>
-            <hr>
-            <p>After</p>
-        "#;
-
-        let markdown = convert_html_to_markdown(html)?;
-        // htmd might render hr differently, just check both paragraphs are present
-        assert!(markdown.contains("Before"));
-        assert!(markdown.contains("After"));
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_empty_elements() -> Result<()> {
-        let html = r#"
-            <p></p>
-            <div></div>
-            <h1></h1>
-        "#;
-
-        let markdown = convert_html_to_markdown(html)?;
-        // Should handle empty elements without crashing
-        assert!(markdown.is_empty() || markdown.trim().is_empty() || markdown.len() < 10);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_nested_formatting() -> Result<()> {
-        let html = r#"
-            <p>Text with <strong>bold and <em>italic</em></strong> combined.</p>
-        "#;
-
-        let markdown = convert_html_to_markdown(html)?;
-        assert!(markdown.contains("bold"));
-        assert!(markdown.contains("italic"));
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_special_characters() -> Result<()> {
-        let html = r#"
-            <p>Special: &lt; &gt; &amp; &quot;</p>
-        "#;
-
-        let markdown = convert_html_to_markdown(html)?;
-        assert!(markdown.contains("<"));
-        assert!(markdown.contains(">"));
-        assert!(markdown.contains("&"));
-        assert!(markdown.contains("\""));
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_script_style_removal() -> Result<()> {
-        let html = r#"
-            <html>
-                <head>
-                    <script>console.log('test');</script>
-                    <style>body { color: red; }</style>
-                </head>
-                <body>
-                    <p>Actual content</p>
-                </body>
-            </html>
-        "#;
-
-        let markdown = convert_html_to_markdown(html)?;
-        // htmd might include script/style content, just verify the main content is there
-        assert!(markdown.contains("Actual content"));
-        // Verify it's not excessively long (scripts/styles might make it longer)
-        assert!(markdown.len() < 500);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_table_conversion() -> Result<()> {
-        let html = r#"
-            <table>
-                <tr>
-                    <th>Header 1</th>
-                    <th>Header 2</th>
-                </tr>
-                <tr>
-                    <td>Cell 1</td>
-                    <td>Cell 2</td>
-                </tr>
-            </table>
-        "#;
-
-        let markdown = convert_html_to_markdown(html)?;
-        // Tables might be converted differently by htmd
-        assert!(markdown.contains("Header 1"));
-        assert!(markdown.contains("Header 2"));
-        assert!(markdown.contains("Cell 1"));
-        assert!(markdown.contains("Cell 2"));
-
-        Ok(())
-    }
-}
-</file>
-
-<file path="testdata/example.sh">
-#!/usr/bin/env bash
-cd "$(dirname "$0")"
-
-echo "https://helpx.adobe.com/pl/indesign/using/using-fonts.html" | ../target/release/twars-url2md --stdin -o out "$@"
-</file>
-
-<file path=".cursorrules">
-# https://github.com/twardoch/twars-url2md
-
-## 1. Project Overview
-
-`twars-url2md` is a Rust CLI application that downloads URLs and converts them to clean, readable Markdown files. It can extract URLs from various text formats and process them concurrently.
-
-## 2. Commands
-
-### 2.1. Development
-```bash
-# Run tests
-cargo test --all-features
-
-# Format code
-cargo fmt
-
-# Run linter
-cargo clippy --all-targets --all-features
-
-# Build release binary
-cargo build --release
-
-# Run with arguments
-cargo run -- [OPTIONS]
-```
-
-### 2.2. Publishing
-```bash
-# Verify package before publishing
-cargo package
-
-# Publish to crates.io
-cargo publish
-```
-
-## 3. Architecture
-
-The codebase follows a modular design with clear separation of concerns:
-
-- `src/main.rs` - Entry point with panic handling wrapper
-- `src/lib.rs` - Core processing logic and orchestration
-- `src/cli.rs` - Command-line interface using Clap
-- `src/url.rs` - URL extraction and validation logic
-- `src/html.rs` - HTML fetching and cleaning using Monolith
-- `src/markdown.rs` - HTML to Markdown conversion using htmd
-
-### 3.1. Key Design Decisions
-
-1. **Panic Recovery**: The application catches panics from the Monolith library to prevent crashes during HTML processing (see `src/main.rs:10-20`).
-
-2. **Concurrent Processing**: Uses Tokio with adaptive concurrency based on available CPUs for parallel URL processing (see `src/lib.rs:107-120`).
-
-3. **Error Handling**: Uses `anyhow` for error propagation with custom error types and retry logic for network failures.
-
-4. **Output Organization**: Generates file paths based on URL structure when using `-o` option, creating a repository-like structure.
-
-## 4. Testing
-
-Run tests with `cargo test --all-features`. The test module is in `src/tests.rs` and includes unit tests for URL extraction and processing logic.
-
-## 5. Dependencies
-
-- **Async Runtime**: tokio with full features
-- **HTTP Client**: reqwest with vendored OpenSSL
-- **HTML Processing**: monolith for cleaning, htmd for Markdown conversion
-- **CLI**: clap with derive feature
-- **Utilities**: indicatif (progress bars), rayon (parallelism)
-
-## 6. Active Development
-
-See `TODO.md` for the modernization plan, which includes:
-- Migration from OpenSSL to rustls
-- Integration of structured logging with tracing
-- Enhanced error reporting
-- Performance optimizations
-
-When implementing new features, ensure compatibility with the async architecture and maintain the modular structure.
-
-# Working principles for software development
-
-## 7. When you write code (in any language)
-
-- Iterate gradually, avoiding major changes 
-- Minimize confirmations and checks
-- Preserve existing code/structure unless necessary
-- Use constants over magic numbers
-- Check for existing solutions in the codebase before starting
-- Check often the coherence of the code you’re writing with the rest of the code. 
-- Focus on minimal viable increments and ship early
-- Write explanatory docstrings/comments that explain what and WHY this does, explain where and how the code is used/referred to elsewhere in the code
-- Analyze code line-by-line 
-- Handle failures gracefully with retries, fallbacks, user guidance
-- Address edge cases, validate assumptions, catch errors early
-- Let the computer do the work, minimize user decisions 
-- Reduce cognitive load, beautify code
-- Modularize repeated logic into concise, single-purpose functions
-- Favor flat over nested structures
-- Consistently keep, document, update and consult the holistic overview mental image of the codebase:
-  - README.md (purpose and functionality) 
-  - CHANGELOG.md (past changes)
-  - TODO.md (future goals)
-  - PROGRESS.md (detailed flat task list)
-
-## 8. Use MCP tools if you can
-
-Before and during coding (if have access to tools), you should: 
-
-- consult the `context7` tool for most up-to-date software package documentation;
-- ask intelligent questions to the `deepseek/deepseek-r1-0528:free` model via the `chat_completion` tool to get additional reasoning;
-- also consult the `openai/o3` model via the `chat_completion` tool for additional reasoning and help with the task;
-- use the `sequentialthinking` tool to think about the best way to solve the task; 
-- use the `perplexity_ask` and `duckduckgo_web_search` tools to gather up-to-date information or context;
-
-## 9. Keep track of paths
-
-In each source file, maintain the up-to-date `this_file` record that shows the path of the current file relative to project root. Place the `this_file` record near the top of the file, as a comment after the shebangs, or in the YAML Markdown frontmatter. 
-
-## 10. If you write Python
-
-- PEP 8: Use consistent formatting and naming
-- Write clear, descriptive names for functions and variables
-- PEP 20: Keep code simple and explicit. Prioritize readability over cleverness
-- Use type hints in their simplest form (list, dict, | for unions)
-- PEP 257: Write clear, imperative docstrings
-- Use f-strings. Use structural pattern matching where appropriate
-- ALWAYS add "verbose" mode logugu-based logging, & debug-log
-- For CLI Python scripts, use fire & rich, and start the script with 
-
-```
-#!/usr/bin/env -S uv run -s
-# /// script
-# dependencies = ["PKG1", "PKG2"]
-# ///
-# this_file: PATH_TO_CURRENT_FILE
-```
-
-After Python changes run:
-
-```
-uzpy run .; fd -e py -x autoflake {}; fd -e py -x pyupgrade --py312-plus {}; fd -e py -x ruff check --output-format=github --fix --unsafe-fixes {}; fd -e py -x ruff format --respect-gitignore --target-version py312 {}; python -m pytest;
-```
-
-## 11. Additional guidelines
-
-Ask before extending/refactoring existing code in a way that may add complexity or break things. 
-
-When you’re finished, print "Wait, but" to go back, think & reflect, revise & improvement what you’ve done (but don’t invent functionality freely). Repeat this. But stick to the goal of "minimal viable next version". 
-
-## 12. Virtual team work
-
-Be creative, diligent, critical, relentless & funny! Lead two experts: "Ideot" for creative, unorthodox ideas, and "Critin" to critique flawed thinking and moderate for balanced discussions. The three of you shall illuminate knowledge with concise, beautiful responses, process methodically for clear answers, collaborate step-by-step, sharing thoughts and adapting. If errors are found, step back and focus on accuracy and progress.
-
-## 13. Development Guidelines
-
-- Only modify code directly relevant to the specific request. Avoid changing unrelated functionality.
-- Never replace code with placeholders like `# ... rest of the processing ...`. Always include complete code.
-- Break problems into smaller steps. Think through each step separately before implementing.
-- Always provide a complete PLAN with REASONING based on evidence from code and logs before making changes.
-- Explain your OBSERVATIONS clearly, then provide REASONING to identify the exact issue. Add console logs when needed to gather more information.
-
-
-The URL-to-markdown conversion system consists of three primary business components:
-
-### 13.1. URL Processing and Content Extraction (Importance: 95)
-- Collects URLs from multiple input sources (stdin, files)
-- Validates and resolves URLs against base URLs when needed
-- Implements a robust retry mechanism for handling transient network failures
-- Processes URLs concurrently with dynamic CPU core adaptation
-- Located in `src/cli.rs` and `src/url.rs`
-
-### 13.2. HTML Processing Pipeline (Importance: 90)
-- Fetches HTML content using Monolith for specialized content extraction
-- Implements fallback mechanisms for non-HTML content
-- Handles custom HTML processing with configurable options
-- Transforms complex HTML structures into clean markdown
-- Located in `src/html.rs`
-
-### 13.3. Content Organization and Output Management (Importance: 85)
-- Creates structured output paths mirroring URL hierarchies
-- Supports packing mode for combining multiple URLs into single documents
-- Maintains original URL ordering in packed output
-- Handles both remote URLs and local file paths consistently
-- Located in `src/lib.rs` and `src/markdown.rs`
-
-### 13.4. Integration Points
-
-The system connects these components through:
-
-1. URL Collection -> HTML Processing
-- URLs are validated and normalized before processing
-- Concurrent processing queue manages HTML fetching
-- Retry logic handles failed attempts
-
-2. HTML Processing -> Content Organization
-- Processed HTML is transformed to markdown
-- Output paths are generated based on URL structure
-- Content is either packed or distributed based on mode
-
-The build system embeds version and build metadata for traceability, ensuring each deployment can be traced to its source state.
-
-To read the full codebase, run `npx repomix -o llms.txt .` and then read `llms.txt`
-
-$END$
-</file>
-
-<file path="build.rs">
-fn main() {
-    built::write_built_file().expect("Failed to acquire build-time information");
-    println!("cargo:rerun-if-changed=build.rs");
-}
-</file>
-
-<file path="build.sh">
-#!/bin/bash
-# this_file: build.sh
-# Build script for twars-url2md - A powerful CLI tool for converting web pages to Markdown
-
-set -euo pipefail
-
-npx repomix -o llms.txt .
-
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
-
-# Function to print colored output
-print_status() {
-    echo -e "${BLUE}[INFO]${NC} $1"
-}
-
-print_success() {
-    echo -e "${GREEN}[SUCCESS]${NC} $1"
-}
-
-print_warning() {
-    echo -e "${YELLOW}[WARNING]${NC} $1"
-}
-
-print_error() {
-    echo -e "${RED}[ERROR]${NC} $1"
-}
-
-# Function to check if command exists
-command_exists() {
-    command -v "$1" >/dev/null 2>&1
-}
-
-# Check prerequisites
-check_prerequisites() {
-    print_status "Checking prerequisites..."
-
-    if ! command_exists cargo; then
-        print_error "cargo is not installed. Please install Rust toolchain first."
-        exit 1
-    fi
-
-    if ! command_exists rustc; then
-        print_error "rustc is not installed. Please install Rust toolchain first."
-        exit 1
-    fi
-
-    print_success "Prerequisites check passed"
-}
-
-# Function to show help
-show_help() {
-    echo "Usage: $0 [OPTIONS]"
-    echo ""
-    echo "Build script for twars-url2md"
-    echo ""
-    echo "OPTIONS:"
-    echo "  -h, --help       Show this help message"
-    echo "  -f, --format     Format code only"
-    echo "  -l, --lint       Run linter only"
-    echo "  -t, --test       Run tests only"
-    echo "  -b, --build      Build release binary only"
-    echo "  -d, --dev        Build development binary only"
-    echo "  -c, --clean      Clean build artifacts"
-    echo "  -p, --package    Package for publishing"
-    echo "  -a, --all        Run all steps (format, lint, test, build) [default]"
-    echo "  --skip-format    Skip formatting step"
-    echo "  --skip-lint      Skip linting step"
-    echo "  --skip-test      Skip testing step"
-    echo ""
-    echo "Examples:"
-    echo "  $0                    # Run all steps"
-    echo "  $0 --format          # Format code only"
-    echo "  $0 --test            # Run tests only"
-    echo "  $0 --all --skip-test # Run all except tests"
-}
-
-# Default values
-FORMAT=false
-LINT=false
-TEST=false
-BUILD=false
-DEV_BUILD=false
-CLEAN=false
-PACKAGE=false
-ALL=true
-SKIP_FORMAT=false
-SKIP_LINT=false
-SKIP_TEST=false
-
-# Parse command line arguments
-while [[ $# -gt 0 ]]; do
-    case $1 in
-    -h | --help)
-        show_help
-        exit 0
-        ;;
-    -f | --format)
-        FORMAT=true
-        ALL=false
-        ;;
-    -l | --lint)
-        LINT=true
-        ALL=false
-        ;;
-    -t | --test)
-        TEST=true
-        ALL=false
-        ;;
-    -b | --build)
-        BUILD=true
-        ALL=false
-        ;;
-    -d | --dev)
-        DEV_BUILD=true
-        ALL=false
-        ;;
-    -c | --clean)
-        CLEAN=true
-        ALL=false
-        ;;
-    -p | --package)
-        PACKAGE=true
-        ALL=false
-        ;;
-    -a | --all)
-        ALL=true
-        ;;
-    --skip-format)
-        SKIP_FORMAT=true
-        ;;
-    --skip-lint)
-        SKIP_LINT=true
-        ;;
-    --skip-test)
-        SKIP_TEST=true
-        ;;
-    *)
-        print_error "Unknown option: $1"
-        echo "Use --help for usage information"
-        exit 1
-        ;;
-    esac
-    shift
-done
-
-# Main execution
-main() {
-    print_status "Starting build process for twars-url2md..."
-    check_prerequisites
-
-    # Clean if requested
-    if [[ $CLEAN == true ]]; then
-        print_status "Cleaning build artifacts..."
-        cargo clean
-        print_success "Clean completed"
-        return 0
-    fi
-
-    # Package if requested
-    if [[ $PACKAGE == true ]]; then
-        print_status "Packaging for publishing..."
-        cargo package
-        print_success "Package completed"
-        return 0
-    fi
-
-    # Format code
-    if [[ ($ALL == true && $SKIP_FORMAT == false) || $FORMAT == true ]]; then
-        print_status "Formatting code..."
-        if cargo fmt -- --check >/dev/null 2>&1; then
-            print_success "Code is already formatted"
-        else
-            print_warning "Code needs formatting, applying..."
-            cargo fmt
-            print_success "Code formatting completed"
-        fi
-    fi
-
-    # Run linter
-    if [[ ($ALL == true && $SKIP_LINT == false) || $LINT == true ]]; then
-        print_status "Running linter (clippy)..."
-        cargo clippy --all-targets --all-features -- -D warnings
-        print_success "Linting completed"
-    fi
-
-    # Run tests
-    if [[ ($ALL == true && $SKIP_TEST == false) || $TEST == true ]]; then
-        print_status "Running tests..."
-        cargo test --all-features
-        print_success "Tests completed"
-    fi
-
-    # Build development binary
-    if [[ $DEV_BUILD == true ]]; then
-        print_status "Building development binary..."
-        cargo build
-        print_success "Development build completed"
-        print_status "Binary location: target/debug/twars-url2md"
-    fi
-
-    # Build release binary
-    if [[ ($ALL == true) || $BUILD == true ]]; then
-        print_status "Building release binary..."
-        cargo build --release
-        print_success "Release build completed"
-        print_status "Binary location: target/release/twars-url2md"
-
-        # Show binary info
-        if [[ -f "target/release/twars-url2md" ]]; then
-            BINARY_SIZE=$(du -h target/release/twars-url2md | cut -f1)
-            print_status "Binary size: $BINARY_SIZE"
-        fi
-    fi
-
-    print_success "Build process completed successfully!"
-}
-
-# Run main function
-main
-</file>
-
-<file path="CLAUDE.md">
-# https://github.com/twardoch/twars-url2md
-
-## 1. Project Overview
-
-`twars-url2md` is a Rust CLI application that downloads URLs and converts them to clean, readable Markdown files. It can extract URLs from various text formats and process them concurrently.
-
-## 2. Commands
-
-### 2.1. Development
-```bash
-# Run tests
-cargo test --all-features
-
-# Format code
-cargo fmt
-
-# Run linter
-cargo clippy --all-targets --all-features
-
-# Build release binary
-cargo build --release
-
-# Run with arguments
-cargo run -- [OPTIONS]
-```
-
-### 2.2. Publishing
-```bash
-# Verify package before publishing
-cargo package
-
-# Publish to crates.io
-cargo publish
-```
-
-## 3. Architecture
-
-The codebase follows a modular design with clear separation of concerns:
-
-- `src/main.rs` - Entry point with panic handling wrapper
-- `src/lib.rs` - Core processing logic and orchestration
-- `src/cli.rs` - Command-line interface using Clap
-- `src/url.rs` - URL extraction and validation logic
-- `src/html.rs` - HTML fetching and cleaning using Monolith
-- `src/markdown.rs` - HTML to Markdown conversion using htmd
-
-### 3.1. Key Design Decisions
-
-1. **Panic Recovery**: The application catches panics from the Monolith library to prevent crashes during HTML processing (see `src/main.rs:10-20`).
-
-2. **Concurrent Processing**: Uses Tokio with adaptive concurrency based on available CPUs for parallel URL processing (see `src/lib.rs:107-120`).
-
-3. **Error Handling**: Uses `anyhow` for error propagation with custom error types and retry logic for network failures.
-
-4. **Output Organization**: Generates file paths based on URL structure when using `-o` option, creating a repository-like structure.
-
-## 4. Testing
-
-Run tests with `cargo test --all-features`. The test module is in `src/tests.rs` and includes unit tests for URL extraction and processing logic.
-
-## 5. Dependencies
-
-- **Async Runtime**: tokio with full features
-- **HTTP Client**: reqwest with vendored OpenSSL
-- **HTML Processing**: monolith for cleaning, htmd for Markdown conversion
-- **CLI**: clap with derive feature
-- **Utilities**: indicatif (progress bars), rayon (parallelism)
-
-## 6. Active Development
-
-See `TODO.md` for the modernization plan, which includes:
-- Migration from OpenSSL to rustls
-- Integration of structured logging with tracing
-- Enhanced error reporting
-- Performance optimizations
-
-When implementing new features, ensure compatibility with the async architecture and maintain the modular structure.
-
-# Working principles for software development
-
-## 7. When you write code (in any language)
-
-- Iterate gradually, avoiding major changes 
-- Minimize confirmations and checks
-- Preserve existing code/structure unless necessary
-- Use constants over magic numbers
-- Check for existing solutions in the codebase before starting
-- Check often the coherence of the code you’re writing with the rest of the code. 
-- Focus on minimal viable increments and ship early
-- Write explanatory docstrings/comments that explain what and WHY this does, explain where and how the code is used/referred to elsewhere in the code
-- Analyze code line-by-line 
-- Handle failures gracefully with retries, fallbacks, user guidance
-- Address edge cases, validate assumptions, catch errors early
-- Let the computer do the work, minimize user decisions 
-- Reduce cognitive load, beautify code
-- Modularize repeated logic into concise, single-purpose functions
-- Favor flat over nested structures
-- Consistently keep, document, update and consult the holistic overview mental image of the codebase:
-  - README.md (purpose and functionality) 
-  - CHANGELOG.md (past changes)
-  - TODO.md (future goals)
-  - PROGRESS.md (detailed flat task list)
-
-## 8. Use MCP tools if you can
-
-Before and during coding (if have access to tools), you should: 
-
-- consult the `context7` tool for most up-to-date software package documentation;
-- ask intelligent questions to the `deepseek/deepseek-r1-0528:free` model via the `chat_completion` tool to get additional reasoning;
-- also consult the `openai/o3` model via the `chat_completion` tool for additional reasoning and help with the task;
-- use the `sequentialthinking` tool to think about the best way to solve the task; 
-- use the `perplexity_ask` and `duckduckgo_web_search` tools to gather up-to-date information or context;
-
-## 9. Keep track of paths
-
-In each source file, maintain the up-to-date `this_file` record that shows the path of the current file relative to project root. Place the `this_file` record near the top of the file, as a comment after the shebangs, or in the YAML Markdown frontmatter. 
-
-## 10. If you write Python
-
-- PEP 8: Use consistent formatting and naming
-- Write clear, descriptive names for functions and variables
-- PEP 20: Keep code simple and explicit. Prioritize readability over cleverness
-- Use type hints in their simplest form (list, dict, | for unions)
-- PEP 257: Write clear, imperative docstrings
-- Use f-strings. Use structural pattern matching where appropriate
-- ALWAYS add "verbose" mode logugu-based logging, & debug-log
-- For CLI Python scripts, use fire & rich, and start the script with 
-
-```
-#!/usr/bin/env -S uv run -s
-# /// script
-# dependencies = ["PKG1", "PKG2"]
-# ///
-# this_file: PATH_TO_CURRENT_FILE
-```
-
-After Python changes run:
-
-```
-uzpy run .; fd -e py -x autoflake {}; fd -e py -x pyupgrade --py312-plus {}; fd -e py -x ruff check --output-format=github --fix --unsafe-fixes {}; fd -e py -x ruff format --respect-gitignore --target-version py312 {}; python -m pytest;
-```
-
-## 11. Additional guidelines
-
-Ask before extending/refactoring existing code in a way that may add complexity or break things. 
-
-When you’re finished, print "Wait, but" to go back, think & reflect, revise & improvement what you’ve done (but don’t invent functionality freely). Repeat this. But stick to the goal of "minimal viable next version". 
-
-## 12. Virtual team work
-
-Be creative, diligent, critical, relentless & funny! Lead two experts: "Ideot" for creative, unorthodox ideas, and "Critin" to critique flawed thinking and moderate for balanced discussions. The three of you shall illuminate knowledge with concise, beautiful responses, process methodically for clear answers, collaborate step-by-step, sharing thoughts and adapting. If errors are found, step back and focus on accuracy and progress.
-
-## 13. Development Guidelines
-
-- Only modify code directly relevant to the specific request. Avoid changing unrelated functionality.
-- Never replace code with placeholders like `# ... rest of the processing ...`. Always include complete code.
-- Break problems into smaller steps. Think through each step separately before implementing.
-- Always provide a complete PLAN with REASONING based on evidence from code and logs before making changes.
-- Explain your OBSERVATIONS clearly, then provide REASONING to identify the exact issue. Add console logs when needed to gather more information.
-
-
-The URL-to-markdown conversion system consists of three primary business components:
-
-### 13.1. URL Processing and Content Extraction (Importance: 95)
-- Collects URLs from multiple input sources (stdin, files)
-- Validates and resolves URLs against base URLs when needed
-- Implements a robust retry mechanism for handling transient network failures
-- Processes URLs concurrently with dynamic CPU core adaptation
-- Located in `src/cli.rs` and `src/url.rs`
-
-### 13.2. HTML Processing Pipeline (Importance: 90)
-- Fetches HTML content using Monolith for specialized content extraction
-- Implements fallback mechanisms for non-HTML content
-- Handles custom HTML processing with configurable options
-- Transforms complex HTML structures into clean markdown
-- Located in `src/html.rs`
-
-### 13.3. Content Organization and Output Management (Importance: 85)
-- Creates structured output paths mirroring URL hierarchies
-- Supports packing mode for combining multiple URLs into single documents
-- Maintains original URL ordering in packed output
-- Handles both remote URLs and local file paths consistently
-- Located in `src/lib.rs` and `src/markdown.rs`
-
-### 13.4. Integration Points
-
-The system connects these components through:
-
-1. URL Collection -> HTML Processing
-- URLs are validated and normalized before processing
-- Concurrent processing queue manages HTML fetching
-- Retry logic handles failed attempts
-
-2. HTML Processing -> Content Organization
-- Processed HTML is transformed to markdown
-- Output paths are generated based on URL structure
-- Content is either packed or distributed based on mode
-
-The build system embeds version and build metadata for traceability, ensuring each deployment can be traced to its source state.
-
-To read the full codebase, run `npx repomix -o llms.txt .` and then read `llms.txt`
-
-$END$
-</file>
-
-<file path="TODO.md">
-# [ ] `twars-url2md` Modernization TODO List
-
-# [ ] Modernization Goals
-
-This document outlines the steps to modernize the `twars-url2md` codebase, focusing on improving maintainability, robustness, developer experience, and leveraging modern Rust practices.
-
-## [ ] 1. Implement smart processing
-
-Unless **`-a` / `--all`** is specified, the scraper applies the following heuristic pipeline to isolate what humans would intuitively regard as the _main_ portion of an HTML page.
-
-### [ ] 1.1. Pre‑flight cleanup
-
-1. **Strip non‑content tags**: remove every `script`, `style`, `noscript`, `template`, `iframe`, `svg`, and `canvas` node.
-2. **Normalise whitespace**: collapse consecutive whitespace and new‑line characters so that subsequent length measurements are stable.
-3. **Discard empty elements**: recursively prune elements that are now empty or contain fewer than _N_ visible characters (default =`25`).
-
-### [ ] 1.2. Single‑element fast path
-
-_If_ exactly **one** `<main>` _or_ **one** `<article>` element remains **after** the pre‑flight cleanup, that element is assumed to hold the canonical content.
-
-- Return its **inner HTML** as the result and **abort** the algorithm.
-
-### [ ] 1.3. Structural pruning
-
-If the fast path did **not** trigger:
-
-**Drop obvious chrome**: delete every `header`, `footer`, `aside`, `nav`, and `form` element (these overwhelmingly host site navigation, sidebars, ads, or comment boxes).
-
-### [ ] 1.4. Behaviour of `-a / --all`
-
-Passing **`-a`** bypasses _all_ of the above logic: the tool will emit the fully cleaned `<body>` after _Pre‑flight cleanup_ (step 1) but before any structural heuristics are applied. This is useful when you explicitly want _everything_ that could conceivably be part of the page's content, for example when converting documentation sites that embed code samples in sidebars.
-
-## [ ] 2. Critical Bug Fixes (HIGH PRIORITY)
-
-### [ ] 2.1. Fix Help Option Not Working (REGRESSION)
-
-- **Issue:** Running `twars-url2md -h` or `twars-url2md --help` produces no output
-- **Root Cause:** The custom argument parsing in `cli.rs:parse_args()` exits with code 0 but doesn't let Clap print the help message
-- **Tasks:**
-  - [ ] Fix the help handling in `parse_args()` to ensure Clap's help text is displayed before exiting
-  - [ ] Test that both `-h` and `--help` work correctly
-  - [ ] Ensure `--version` also displays properly
-
-### [x] 2.2. Enhance Error Message for Missing Input
-
-- **Issue:** When running `twars-url2md` without arguments, the error message is too brief
-- **Current:** "Error: Either --stdin or --input must be specified\nRun with --help for usage information"
-- **Tasks:**
-  - [x] Update error message to include a brief usage example
-  - [x] Consider showing a condensed help message when no arguments are provided
-  - [x] Make the error message more helpful for first-time users
-
-### [ ] 2.3. Fix URL Processing Stalling Issue
-
-- **Issue:** Processing URLs (e.g., `echo "https://helpx.adobe.com/pl/indesign/using/using-fonts.html" | twars-url2md --stdin`) stalls after printing "Processing URL:" message
-- **Root Cause Analysis:**
-  - The code creates directories but doesn't complete the processing
-  - The monolith processing might be hanging or timing out
-  - No timeout is set for the HTTP requests or monolith processing
-- **Tasks:**
-  - [ ] Add comprehensive timeout handling for HTTP requests
-  - [ ] Add timeout for monolith processing in `spawn_blocking` task
-  - [ ] Add more detailed progress logging to identify where the stall occurs
-  - [ ] Ensure error messages are properly propagated when processing fails
-  - [ ] Test with various URLs to ensure robustness
-  - [x] Refactor `fetch_html` in `src/html.rs` to handle errors from `monolith` gracefully without relying on `std::panic::catch_unwind`. Explore `monolith`'s error reporting capabilities or use it in a way that's less prone to panicking.
-  - [ ] Remove the top-level `panic::set_hook` and `panic::catch_unwind` in `main.rs` if underlying issues are resolved. The goal is for the application to exit cleanly with an error message via `Result` propagation.
-
-### [ ] 2.4. Fix Output Writing Issues
-
-- **Issue:** When using `-p out.md` or `-o out`, no output files are created
-- **Root Cause:** Need to verify the output writing logic in both pack and regular modes
-- **Tasks:**
-  - [ ] Debug why files aren't being written when output options are specified
-  - [ ] Ensure parent directories are created properly
-  - [ ] Add logging to confirm when files are successfully written
-  - [ ] Test all output modes: stdout, single file, directory structure, and pack mode
-  - [ ] Add helper `fn output_mode(path: &Path) -> OutputMode` where `enum OutputMode { Directory(PathBuf), SingleFile(PathBuf) }`.
-  - [ ] In `Cli::create_config` detect `path.extension() == Some("md".as_ref())` ⇒ `SingleFile` else `Directory`.
-  - [ ] Propagate this choice via `Config` (replace the boolean pair `single_file`/`has_output` with `output_kind: OutputKind`).
-  - [ ] Update `lib::process_urls` to:
-     • write each URL into its own file when `Directory`, preserving the current hierarchy logic;  
-     • write (append) all Markdown into the single file when `SingleFile`, prefixed with `# {url}` separators (same formatter used by `--pack`).
-  - [ ] Make `--pack` mutually exclusive with single-file mode. Clap can enforce this via `.conflicts_with("output")` when `output` ends in `.md`.
-  - [ ] Ensure parent directories exist for both modes using `tokio::fs::create_dir_all` with error propagation.
-  - [ ] Add extensive logging: `tracing::debug!(%path, "wrote file")` for every successful write; `tracing::error!` for failures.
-  - [ ] Integration tests (`tests/output_modes.rs`) covering:
-       - directory mode (`-o outdir`);
-       - single-file mode (`-o out.md`);
-       - pack mode (`-p combined.md` with multiple URLs);
-       verify file existence and that the first 10 chars of content are non-empty Markdown.
-
-## [ ] 3. Logging Framework Integration
-
-- **Goal:** Replace current `eprintln!`-based verbose/debug logging with a structured logging framework.
-- **Tasks:**
-  - [x] Add `tracing` and `tracing-subscriber` to `Cargo.toml`.
-  - [x] Configure `tracing-subscriber` (e.g., using `fmt` layer and `EnvFilter` for level control via environment variable like `RUST_LOG`).
-  - [x] Initialize the subscriber early in `main()`.
-  - [x] Replace all instances of `eprintln!` used for debugging, verbose output, or warnings with appropriate `tracing` macros (`trace!`, `debug!`, `info!`, `warn!`, `error!`).
-  - [ ] Update `README.md` or provide usage instructions on how to control log levels.
-
-## [ ] 4. Error Handling Refinement
-
-- **Goal:** Standardize error handling using `anyhow` and eliminate panics for recoverable errors.
-- **Tasks:**
-  - [x] Review `src/error.rs`. Decide if the custom `Error` enum provides significant benefits over `anyhow::Error`.
-    - If kept, ensure it implements `std::error::Error` and has clean `From` implementations for `anyhow::Error` and other error types.
-    - If not, remove it and use `anyhow::Error` or `anyhow::Result` directly.
-  - [ ] Systematically replace all `unwrap()`, `expect()`, and potential panicking operations with `?` or `Result::map_err`/`with_context`.
-  - [x] Refactor `fetch_html`
-
-## [ ] 5. Dependency Review and Management
-
-- **Goal:** Ensure dependencies are optimal, up-to-date, and managed effectively.
-- **Tasks:**
-  - [ ] **(Major)** Investigate replacing `openssl` (vendored) with `rustls` for TLS handling in `reqwest`.
-    - Change features for `reqwest` in `Cargo.toml`.
-    - Test thoroughly on all target platforms (Linux, macOS, Windows).
-    - This could simplify cross-compilation and reduce binary size/non-Rust dependencies.
-  - [ ] Re-evaluate `monolith`'s role.
-    - Determine if its full capabilities are necessary or if a lighter HTML fetching/cleaning approach would suffice, potentially reducing complexity and improving robustness.
-    - If kept, ensure its integration is as fault-tolerant as possible.
-  - [ ] Update other dependencies to their latest compatible versions using `cargo update`.
-  - [ ] Run `cargo audit` to check for security vulnerabilities in dependencies and address any findings. This should be added to CI.
-
-## [ ] 6. Code Refactoring and Optimization
-
-- **Goal:** Improve code clarity, reduce duplication, and enhance performance where sensible.
-- **Tasks:**
-  - [x] In `src/html.rs`:
-    - Refactor `process_url_async` and `process_url_with_content` to share common logic and reduce code duplication. One function could call the other or both could call a common internal helper.
-    - Improve the robustness of `fetch_html`, especially the fallback logic if `monolith` processing fails or is bypassed.
-  - [x] In `src/url.rs`:
-    - Review URL extraction functions (`extract_urls_from_text`, `extract_urls_from_html_efficient`, `extract_urls_from_html`) for clarity and potential performance bottlenecks. Consolidate if possible.
-    - Consider moving URL _processing_ logic (like `process_url_with_retry`, `process_url_with_content`) to `src/html.rs` or a new `src/processor.rs` module, keeping `src/url.rs` focused on URL parsing and path generation.
-  - [ ] Review use of `Arc<Mutex<Vec>>` for `packed_content` in `src/lib.rs`. Ensure this is the most efficient way to collect results, especially concerning locking. For collecting results from async tasks, channels (`tokio::sync::mpsc`) might be an alternative, though the current approach might be fine given the context.
-
-## [ ] 7. Enhanced Testing Strategy
-
-- **Goal:** Increase test coverage and improve the reliability of tests.
-- **Tasks:**
-  - [ ] Write more unit tests for:
-    - `src/url.rs`: Edge cases in URL parsing, base URL resolution, local file path detection.
-    - `src/html.rs`: Different HTML structures, error conditions during fetching/processing, content-type handling.
-    - `src/markdown.rs`: Various HTML inputs and their expected Markdown output.
-    - `src/cli.rs`: Argument parsing logic and configuration creation.
-  - [ ] Integrate `mockito` (already a dev-dependency) or `wiremock-rs` to mock HTTP server responses. This will allow testing of `src/html.rs`'s network interaction logic (retries, error handling) reliably without actual network calls.
-  - [ ] Develop integration tests:
-    - These tests should compile the binary and run it as a subprocess.
-    - Test various CLI argument combinations.
-    - Verify file outputs (existence, naming, content) and stdout.
-    - Test with sample input files containing URLs and local paths.
-  - [ ] Set up code coverage reporting using `cargo-tarpaulin` or `grcov`.
-
-## [ ] 8. Build and CI/CD Enhancements
-
-- **Goal:** Make the build process more robust, secure, and informative.
-- **Tasks:**
-  - [ ] Add code coverage reporting (e.g., `cargo-tarpaulin`) to the CI workflow (`.github/workflows/ci.yml`). Upload coverage reports to a service like Codecov or Coveralls, or as a GitHub artifact.
-  - [ ] Add `cargo audit` to the CI workflow to check for vulnerable dependencies.
-  - [ ] Ensure `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` are strictly enforced in CI.
-
-## [ ] 9. Streamline Release Process
-
-- **Goal:** Automate and simplify the steps involved in releasing new versions.
-- **Tasks:**
-  - [ ] Introduce `cargo-release` as a development dependency or recommend its global installation for maintainers.
-  - [ ] Update `README.md` (`Development` → `Publishing` section) with instructions on using `cargo-release` to manage version bumps, tagging, and publishing.
-  - [ ] Evaluate if the GitHub Actions `publish-crate` job can be simplified or triggered more directly by `cargo-release` conventions (e.g., publishing on tag push is already good).
-
-## [ ] 10. Documentation Improvements
-
-- **Goal:** Ensure documentation is comprehensive, up-to-date, and useful for both users and contributors (including AI).
-- **Tasks:**
-  - [ ] Create `AGENTS.md` in the repository root. This file should include:
-    - Guidance on coding style (e.g., "follow `rustfmt` and `clippy` recommendations").
-    - Instructions for running tests, including any specific setup for integration tests.
-    - Key architectural decisions or module responsibilities.
-    - Notes on how to handle dependencies or build issues.
-  - [ ] Review and enhance inline code documentation (Rustdoc comments `///` and `//!`). Focus on public APIs, complex functions, and any non-obvious logic.
-  - [ ] Ensure `README.md` is updated to reflect any changes in CLI options, behavior, or build/contribution process resulting from this modernization effort.
-
-## [ ] 11. Final Review and Submission
-
-- **Goal:** Ensure all changes are correct, well-tested, and meet the project's standards.
-- **Tasks:**
-  - [ ] Perform a full round of testing: `cargo test --all-features`.
-  - [ ] Run linters and formatters: `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`.
-  - [ ] Manually test the CLI with a diverse set of inputs (various URLs, local files, stdin, different output options).
-  - [ ] Review all code changes for correctness, clarity, and adherence to the modernization goals.
-  - [ ] Commit changes with a clear, descriptive message and submit.
-
-This `TODO.md` will serve as a checklist for the modernization effort.
-</file>
-
-<file path=".gitignore">
-**/*.rs.bk
-*.pdb
-._*
-.apdisk
-.AppleDB
-.AppleDesktop
-.AppleDouble
-.com.apple.timemachine.donotpresent
-.DocumentRevisions-V100
-.DS_Store
-.fseventsd
-.idea/
-.LSOverride
-.Spotlight-V100
-.TemporaryItems
-.Trashes
-.VolumeIcon.icns
-.vscode/
-debug/
-Icon
-Network Trash Folder
-target/
-Temporary Items
-work/
-/.specstory
-</file>
-
-<file path="CHANGELOG.md">
-# Changelog
-
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
-### Fixed
-- Fixed `-h` and `--help` options not printing help message (cli.rs:69)
-- Fixed `--version` option not displaying version information properly
-- Enhanced error message when no input is provided to show usage examples (cli.rs:58-63)
-- Removed unused import warning in url.rs
-
-### Changed
-- Help and version errors are now properly printed before exiting the application
-- Error message for missing input now includes helpful usage examples
-
-## [1.4.2] - Previous release
-</file>
-
-<file path="src/lib.rs">
-use crate::url::Url;
-use anyhow::Result;
-use futures::stream::{self, StreamExt};
-use std::path::PathBuf;
-use std::sync::Arc;
-use std::thread;
-
-pub mod cli;
-// mod error; // Removed
-mod html;
-mod markdown;
-pub mod url;
-
-pub use cli::Cli;
-// pub use error::Error; // Removed
-
-include!(concat!(env!("OUT_DIR"), "/built.rs"));
-
-/// Version information with build details
-pub fn version() -> String {
-    format!(
-        "{}\nBuild Time: {}\nTarget: {}\nProfile: {}",
-        env!("CARGO_PKG_VERSION"),
-        BUILT_TIME_UTC,
-        TARGET,
-        PROFILE
-    )
-}
-
-/// Default user agent string for HTTP requests
-pub(crate) const USER_AGENT_STRING: &str =
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
-
-/// Configuration for URL processing
-#[derive(Debug, Clone)]
-pub struct Config {
-    pub verbose: bool,
-    pub max_retries: u32,
-    pub output_base: PathBuf,
-    pub single_file: bool,
-    pub has_output: bool,
-    pub pack_file: Option<PathBuf>,
-}
-
-/// Process a list of URLs with the given configuration
-pub async fn process_urls(
-    urls: Vec<String>,
-    config: Config,
-) -> Result<Vec<(String, anyhow::Error)>> {
-    use indicatif::{ProgressBar, ProgressStyle};
-    use tokio::io::AsyncWriteExt;
-
-    let pb = if urls.len() > 1 {
-        let pb = ProgressBar::new(urls.len() as u64);
-        let style = ProgressStyle::default_bar()
-            .template(
-                "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} ({eta})",
-            )
-            .map_err(|e| {
-                tracing::warn!(
-                    "Failed to create progress bar template: {}. Using default style.",
-                    e
-                )
-            })
-            .unwrap_or_else(|_| ProgressStyle::default_bar()) // Fallback to default style
-            .progress_chars("#>-");
-        pb.set_style(style);
-        Some(pb)
-    } else {
-        None
-    };
-
-    let pb = Arc::new(pb);
-    // Adaptive concurrency based on CPU cores
-    let concurrency_limit = thread::available_parallelism()
-        .map(|n| n.get() * 2) // 2 tasks per CPU core
-        .unwrap_or(10);
-    tracing::debug!("Concurrency limit set to: {}", concurrency_limit);
-
-    // If pack_file is specified, collect the markdown content
-    let should_pack = config.pack_file.is_some();
-    let pack_path = config.pack_file.clone();
-    let packed_content = if should_pack {
-        tracing::debug!("Packing mode enabled. Output will be: {:?}", pack_path);
-        Arc::new(tokio::sync::Mutex::new(Vec::with_capacity(urls.len())))
-    } else {
-        Arc::new(tokio::sync::Mutex::new(Vec::new())) // Empty vec if not packing
-    };
-
-    // Clone the URLs vector before moving it into the stream for ordering packed content later
-    let urls_for_ordering = if should_pack {
-        urls.clone()
-    } else {
-        Vec::new()
-    };
-
-    let results = stream::iter(urls.into_iter().map(|url_str| {
-        let pb_clone = Arc::clone(&pb);
-        let config_clone = config.clone();
-        let packed_content_clone = Arc::clone(&packed_content);
-        async move {
-            tracing::info!("Processing URL: {}", url_str);
-            match Url::parse(&url_str) {
-                Ok(url_parsed) => {
-                    let out_path = if config_clone.single_file
-                        && config_clone.has_output
-                        && !config_clone.output_base.is_dir()
-                    {
-                        Some(config_clone.output_base)
-                    } else {
-                        match url::create_output_path(&url_parsed, &config_clone.output_base) {
-                            Ok(p) => Some(p),
-                            Err(e) => {
-                                tracing::error!("Failed to create output path for {}: {}", url_str, e);
-                                None
-                            }
-                        }
-                    };
-                    tracing::debug!("Output path for {}: {:?}", url_str, out_path);
-
-                    let result = if should_pack {
-                        // Process URL and collect content for packing
-                        // Calls html::process_url_content_with_retry now
-                        match html::process_url_content_with_retry(
-                            &url_str,
-                            out_path,
-                            config_clone.max_retries,
-                        )
-                        .await
-                        {
-                            Ok(content_opt) => {
-                                if let Some(md_content) = content_opt {
-                                    // md_content will be empty if it's a real empty page,
-                                    // content_opt will be None if it was a non-HTML skip.
-                                    // The packing logic should only add non-empty actual content.
-                                    // The current check `if !md_content.is_empty()` is correct.
-                                    if !md_content.is_empty() {
-                                        let mut content_vec = packed_content_clone.lock().await;
-                                        content_vec.push((url_str.clone(), md_content));
-                                        tracing::debug!("Collected content for packing for URL: {}", url_str);
-                                    } else {
-                                        tracing::debug!("Content for URL {} is empty, not packing. (Could be actual empty page or handled skip)", url_str);
-                                    }
-                                } else {
-                                     tracing::debug!("URL {} was skipped (e.g. non-HTML), no content to pack.", url_str);
-                                }
-                                Ok(())
-                            }
-                            Err(e) => {
-                                tracing::warn!("Failed to process and get content for {}: {}", url_str, e.1);
-                                Err(e)
-                            }
-                        }
-                    } else {
-                        // Process URL normally (writes to file or stdout via process_url_async)
-                        // Calls html::process_url_with_retry now
-                        html::process_url_with_retry(
-                            &url_str,
-                            out_path,
-                            config_clone.max_retries,
-                        )
-                        .await
-                    };
-
-                    if let Some(pb_instance) = &*pb_clone {
-                        pb_instance.inc(1);
-                    }
-                    result
-                }
-                Err(e) => {
-                    tracing::error!("Failed to parse URL {}: {}", url_str, e);
-                    if let Some(pb_instance) = &*pb_clone {
-                        pb_instance.inc(1);
-                    }
-                    Err((url_str, e.into()))
-                }
-            }
-        }
-    }))
-    .buffer_unordered(concurrency_limit)
-    .collect::<Vec<_>>()
-    .await;
-
-    if let Some(pb_instance) = &*pb {
-        pb_instance.finish_with_message("Processing complete!");
-        // pb_instance.finish_and_clear(); // Optionally clear the progress bar
-    }
-
-    // Write the packed content to the specified file
-    if let Some(path) = pack_path {
-        tracing::info!("Writing packed content to {}", path.display());
-
-        if let Some(parent) = path.parent() {
-            if !parent.exists() {
-                tracing::debug!(
-                    "Creating parent directory for packed file: {}",
-                    parent.display()
-                );
-                if let Err(e) = tokio::fs::create_dir_all(parent).await {
-                    tracing::error!(
-                        "Failed to create directory {} for packed file: {}",
-                        parent.display(),
-                        e
-                    );
-                    // Continue to attempt writing, but log the error.
-                }
-            }
-        }
-
-        let mut packed_file = match tokio::fs::File::create(&path).await {
-            Ok(file) => file,
-            Err(e) => {
-                tracing::error!(
-                    "Fatal: Error creating packed file {}: {}",
-                    path.display(),
-                    e
-                );
-                // Collect all errors from processing and return them
-                return Ok(results.into_iter().filter_map(|r| r.err()).collect());
-            }
-        };
-
-        // Get the locked packed_content
-        let mut content_to_write = packed_content.lock().await;
-
-        // Reorder packed_content to match the original URL order
-        if !urls_for_ordering.is_empty() {
-            let mut url_to_index = std::collections::HashMap::new();
-            for (i, u) in urls_for_ordering.iter().enumerate() {
-                url_to_index.insert(u.clone(), i);
-            }
-
-            content_to_write.sort_by(|a, b| {
-                let a_idx = url_to_index.get(&a.0).unwrap_or(&usize::MAX);
-                let b_idx = url_to_index.get(&b.0).unwrap_or(&usize::MAX);
-                a_idx.cmp(b_idx)
-            });
-            tracing::debug!("Packed content reordered according to input URL order.");
-        }
-
-        for (url_str, content) in content_to_write.iter() {
-            let formatted_entry = format!("# {}\n\n{}\n\n---\n\n", url_str, content);
-            if let Err(e) = packed_file.write_all(formatted_entry.as_bytes()).await {
-                tracing::error!(
-                    "Error writing entry for {} to packed file {}: {}",
-                    url_str,
-                    path.display(),
-                    e
-                );
-            }
-        }
-        tracing::info!(
-            "Successfully wrote {} entries to packed file {}",
-            content_to_write.len(),
-            path.display()
-        );
-    }
-
-    // Collect and return errors
-    let mut errors = Vec::new();
-    for r in results {
-        if let Err(e) = r {
-            // Error already logged at source, just collect for summary
-            errors.push(e);
-        }
-    }
-
-    Ok(errors)
-}
-</file>
-
 <file path=".github/workflows/ci.yml">
 name: CI/CD Pipeline
 
@@ -2850,6 +469,62 @@ jobs:
         run: cargo publish --token ${CRATES_TOKEN} --allow-dirty
         env:
           CRATES_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+</file>
+
+<file path="issues/issue101.txt">
+```
+twars-url2md -h
+```
+
+Nothing is printed. The usage help should be printed.
+
+---
+
+```
+twars-url2md
+```
+
+prints
+
+```
+Error: Either --stdin or --input must be specified
+Run with --help for usage information
+```
+
+Not much. Should be more extensive (basically same as `-h` output).
+
+---
+
+```
+echo "https://helpx.adobe.com/pl/indesign/using/using-fonts.html" | twars-url2md --stdin
+```
+
+this prints
+
+```
+2025-06-24T16:30:54.141096Z  INFO twars_url2md::cli: Reading URLs from stdin.
+2025-06-24T16:30:54.142688Z  INFO twars_url2md: Collected 1 URLs to process.
+2025-06-24T16:30:54.143531Z  INFO twars_url2md: Processing URL: https://helpx.adobe.com/pl/indesign/using/using-fonts.html
+```
+
+but then it stalls. It creates some subfolders (based on the domain URL structure) but that's it.
+
+
+```
+echo "https://helpx.adobe.com/pl/indesign/using/using-fonts.html" | twars-url2md --stdin -p out.md
+```
+
+or
+
+```
+echo "https://helpx.adobe.com/pl/indesign/using/using-fonts.html" | twars-url2md --stdin -o out
+```
+
+prints the `Processing URL:` etc. but then nothing gets written.
+
+<task>
+Read `./README.md` to understand how the app should work. Then write into `./TODO.md` a detailed plan on how you want to fix the issues described above.
+</task>
 </file>
 
 <file path="src/cli.rs">
@@ -3109,625 +784,6 @@ mod tests {
         assert_eq!(urls.len(), 6, "Expected exactly 6 valid URLs");
     }
 }
-</file>
-
-<file path="src/url.rs">
-use anyhow::{Context, Result};
-use html5ever::parse_document;
-use html5ever::tendril::TendrilSink;
-use linkify::{LinkFinder, LinkKind};
-use markup5ever_rcdom as rcdom;
-// anyhow::Context is already imported via `use anyhow::{Context, Result};`
-// use rayon::prelude::*; // No longer used after removing extract_urls_from_html_efficient
-use regex;
-use std::path::{Path, PathBuf};
-pub use url::Url;
-
-/// Create an output path for a URL based on its structure
-pub fn create_output_path(url: &Url, base_dir: &Path) -> Result<PathBuf> {
-    let host = url.host_str().unwrap_or("unknown");
-
-    let path_segments: Vec<_> = url.path().split('/').filter(|s| !s.is_empty()).collect();
-
-    // Build the directory path, including trailing-segment directories if the URL ends with '/'
-    let mut dir_path_full = base_dir.join(host);
-
-    // Decide which segments belong to directories vs. filename
-    let segments_for_dirs: &[&str] = if path_segments.is_empty() {
-        &[]
-    } else if url.path().ends_with('/') {
-        // All segments are directories when URL ends with '/'
-        &path_segments[..]
-    } else {
-        // All except the last segment represent directories
-        &path_segments[..path_segments.len() - 1]
-    };
-
-    for segment in segments_for_dirs {
-        dir_path_full = dir_path_full.join(segment);
-    }
-
-    // Ensure directories exist on disk
-    std::fs::create_dir_all(&dir_path_full)
-        .with_context(|| format!("Failed to create directory: {}", dir_path_full.display()))?;
-
-    // Determine filename
-    let filename = if url.path().ends_with('/') || path_segments.is_empty() {
-        "index.md".to_string()
-    } else {
-        let last_segment = path_segments.last().unwrap();
-        Path::new(last_segment)
-            .file_stem()
-            .map(|s| format!("{}.md", s.to_string_lossy()))
-            .unwrap_or_else(|| format!("{}.md", last_segment))
-    };
-
-    Ok(dir_path_full.join(filename))
-}
-
-/// Extract URLs from any text input
-pub fn extract_urls_from_text(text: &str, base_url: Option<&str>) -> Vec<String> {
-    // Pre-allocate with a reasonable capacity based on text length
-    let estimated_capacity = text.len() / 100; // More conservative estimate
-    let mut urls = Vec::with_capacity(estimated_capacity.min(1000));
-
-    // Add logic to identify local file paths
-    // This regex is static and assumed to be valid. Panicking here is acceptable if it's malformed.
-    let file_regex = regex::Regex::new(r"^(file://)?(/[^/\s]+(?:/[^/\s]+)*\.html?)$")
-        .expect("Invalid static regex for file paths");
-
-    // Process text lines to extract URLs and local file paths
-    for line in text.lines() {
-        let line = line.trim();
-
-        // Check if line is a local file path
-        if file_regex.is_match(line) {
-            // Convert to file:// URL format if not already
-            let file_url = if line.starts_with("file://") {
-                line.to_string()
-            } else {
-                format!("file://{}", line)
-            };
-            urls.push(file_url);
-        } else if !line.is_empty() {
-            // Process as regular URL
-            process_text_chunk(line, base_url, &mut urls);
-        }
-    }
-
-    // Use unstable sort for better performance since order doesn't matter for deduplication
-    urls.sort_unstable();
-    urls.dedup();
-    urls
-}
-
-/// Process a chunk of text to extract URLs
-fn process_text_chunk(text: &str, base_url: Option<&str>, urls: &mut Vec<String>) {
-    let trimmed_text = text.trim();
-    if trimmed_text.starts_with('<') {
-        // Attempt to parse as HTML if it looks like an HTML tag/document fragment
-        match extract_urls_from_html(trimmed_text, base_url) {
-            Ok(extracted) => {
-                urls.extend(extracted);
-            }
-            Err(e) => {
-                // Log the error and fall back to simple LinkFinder for this chunk
-                tracing::debug!(
-                    "Failed to parse text chunk as HTML ({}): '{}...'. Falling back to LinkFinder.",
-                    e,
-                    trimmed_text.chars().take(50).collect::<String>()
-                );
-                let finder = LinkFinder::new();
-                urls.extend(finder.links(trimmed_text).filter_map(|link| {
-                    if link.kind() == &LinkKind::Url {
-                        try_parse_url(link.as_str(), base_url)
-                    } else {
-                        None
-                    }
-                }));
-            }
-        }
-    } else {
-        // Standard LinkFinder for non-HTML-like text
-        let finder = LinkFinder::new();
-        urls.extend(finder.links(trimmed_text).filter_map(|link| {
-            if link.kind() == &LinkKind::Url {
-                try_parse_url(link.as_str(), base_url)
-            } else {
-                None
-            }
-        }));
-    }
-}
-
-// Removed extract_urls_from_html_efficient.
-// Its logic will be integrated into process_text_chunk's fallback,
-// and extract_urls_from_html is the primary method for HTML content.
-
-/// Extract URLs from HTML content, including attributes and text content
-pub fn extract_urls_from_html(html: &str, base_url: Option<&str>) -> Result<Vec<String>> {
-    let mut urls = Vec::new();
-
-    // Parse HTML document
-    let dom = parse_document(rcdom::RcDom::default(), Default::default())
-        .from_utf8()
-        .read_from(&mut html.as_bytes())
-        .map_err(|e| anyhow::anyhow!("Failed to parse HTML for URL extraction: {}", e))?;
-
-    // Extract URLs from HTML structure using iterative approach
-    let mut stack = vec![dom.document.clone()];
-    while let Some(node) = stack.pop() {
-        // Process element nodes
-        if let rcdom::NodeData::Element { ref attrs, .. } = node.data {
-            let attrs = attrs.borrow();
-
-            // Define URL-containing attributes to check
-            let url_attrs = ["href", "src", "data-src", "data-href", "data-url"];
-
-            for attr in attrs.iter() {
-                let attr_name = attr.name.local.to_string();
-                let attr_value = attr.value.to_string();
-
-                if url_attrs.contains(&attr_name.as_str()) {
-                    if let Some(url) = try_parse_url(&attr_value, base_url) {
-                        urls.push(url);
-                    }
-                } else if attr_name == "srcset" {
-                    // Handle srcset attribute which may contain multiple URLs
-                    for src in attr_value.split(',') {
-                        let src = src.split_whitespace().next().unwrap_or("");
-                        if let Some(url) = try_parse_url(src, base_url) {
-                            urls.push(url);
-                        }
-                    }
-                }
-            }
-        }
-
-        // Add child nodes to stack
-        for child in node.children.borrow().iter() {
-            stack.push(child.clone());
-        }
-    }
-
-    // Use LinkFinder as a fallback to catch any remaining URLs in text content
-    let finder = LinkFinder::new();
-    for link in finder.links(html) {
-        if link.kind() == &LinkKind::Url {
-            if let Some(url) = try_parse_url(link.as_str(), base_url) {
-                urls.push(url);
-            }
-        }
-    }
-
-    // Deduplicate and sort URLs
-    urls.sort();
-    urls.dedup();
-    Ok(urls)
-}
-
-fn try_parse_url(url_str: &str, base_url: Option<&str>) -> Option<String> {
-    // Skip obvious non-URLs
-    if url_str.trim().is_empty()
-        || url_str.starts_with("data:")
-        || url_str.starts_with("javascript:")
-        || url_str.starts_with('#')
-        || url_str.contains('{')
-        || url_str.contains('}')
-        || url_str.contains('(')
-        || url_str.contains(')')
-        || url_str.contains('[')
-        || url_str.contains(']')
-        || url_str.contains('<')
-        || url_str.contains('>')
-        || url_str.contains('"')
-        || url_str.contains('\'')
-        || url_str.contains('`')
-        || url_str.contains('\n')
-        || url_str.contains('\r')
-        || url_str.contains('\t')
-        || url_str.contains(' ')
-    {
-        return None;
-    }
-
-    // Handle file:// URLs
-    if url_str.starts_with("file://") {
-        return Some(url_str.to_string());
-    }
-
-    // Check if it could be a local file path
-    if url_str.starts_with('/') && Path::new(url_str).exists() {
-        return Some(format!("file://{}", url_str));
-    }
-
-    // Try parsing as absolute URL first
-    if let Ok(url) = Url::parse(url_str) {
-        if url.scheme() == "http" || url.scheme() == "https" {
-            // Normalize: drop trailing slash for bare domain URLs ("https://example.com/")
-            let mut normalized = url.to_string();
-            if url.path() == "/" && url.query().is_none() && url.fragment().is_none() {
-                normalized.pop(); // remove the trailing '/'
-            }
-            return Some(normalized);
-        }
-    }
-
-    // If we have a base URL and the input looks like a relative URL, try joining
-    if let Some(base) = base_url {
-        if let Ok(base_url) = Url::parse(base) {
-            if let Ok(url) = base_url.join(url_str) {
-                if url.scheme() == "http" || url.scheme() == "https" {
-                    return Some(url.to_string());
-                }
-            }
-        }
-    }
-
-    None
-}
-
-// process_url_with_retry and process_url_with_content (with retry logic)
-// have been moved to src/html.rs and made pub(crate) there.
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use tempfile::TempDir;
-
-    #[test]
-    fn test_extract_urls_from_text() {
-        let text = r#"
-            https://example.com
-            http://test.org
-            Invalid: ftp://example.com
-            https://example.com/path?query=value#fragment
-        "#;
-
-        let urls = extract_urls_from_text(text, None);
-        assert_eq!(urls.len(), 3);
-        assert!(urls.iter().any(|u| u.starts_with("https://example.com")));
-        assert!(urls.iter().any(|u| u.starts_with("http://test.org")));
-    }
-
-    #[tokio::test]
-    async fn test_create_output_path() -> Result<()> {
-        let temp_dir = TempDir::new()?;
-
-        let url = Url::parse("https://example.com/path/page")?;
-        let path = create_output_path(&url, temp_dir.path())?;
-
-        assert!(path.starts_with(temp_dir.path()));
-        assert!(path.to_string_lossy().contains("example.com"));
-        assert!(path.to_string_lossy().ends_with(".md"));
-
-        Ok(())
-    }
-}
-</file>
-
-<file path="README.md">
-# twars-url2md
-
-[![Crates.io](https://img.shields.io/crates/v/twars-url2md)](https://crates.io/crates/twars-url2md)
-![GitHub Release Date](https://img.shields.io/github/release-date/twardoch/twars-url2md)
-![GitHub commits since latest release](https://img.shields.io/github/commits-since/twardoch/twars-url2md/latest)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-
-**`twars-url2md`** is a fast and robust command-line tool written in Rust that fetches web pages, cleans up their HTML content, and converts them into clean Markdown.
-
-You can drop a text that contains URLs onto the app, and it will find all the URLs and save Markdown versions of the pages in a logical folder structure. The output is not perfect, but the tool is fast and robust.
-
-## 1. Table of Contents
-
-- [Features](#features)
-- [Installation](#installation)
-- [Usage](#usage)
-- [Examples](#examples)
-- [Development](#development)
-- [License](#license)
-- [Author](#author)
-
-## 2. Features
-
-### 2.1. Powerful Web Content Conversion
-
-- Extracts clean web content using Monolith
-- Converts web pages to Markdown efficiently
-- Handles complex URL and encoding scenarios
-
-### 2.2. Smart URL Handling
-
-- Extracts URLs from various text formats
-- Resolves and validates URLs intelligently
-- Supports base URL and relative link processing
-- **NEW**: Processes local HTML files in addition to remote URLs
-
-### 2.3. Flexible Input & Output
-
-- Multiple input methods (file, stdin, CLI)
-- Organized Markdown file generation
-- Cross-platform compatibility
-- **NEW**: Option to pack all Markdown outputs into a single combined file
-
-### 2.4. Advanced Processing
-
-- Parallel URL processing
-- Robust error handling
-- Exponential backoff retry mechanism for network requests
-
-## 3. Installation
-
-### 3.1. Download Pre-compiled Binaries
-
-The easiest way to get started is to download the pre-compiled binary for your platform.
-
-1. Visit the [releases page](https://github.com/twardoch/twars-url2md/releases)
-2. Download the appropriate file for your system:
-   - **macOS**: `twars-url2md-macos-universal.tar.gz` (works on both Intel and Apple Silicon)
-   - **Windows**: `twars-url2md-windows-x86_64.exe.zip`
-   - **Linux**: `twars-url2md-linux-x86_64.tar.gz`
-3. Extract the archive:
-   - **macOS/Linux**: `tar -xzf twars-url2md-*.tar.gz`
-   - **Windows**: Extract the zip file using Explorer or any archive utility
-4. Make the binary executable (macOS/Linux only): `chmod +x twars-url2md`
-5. Move the binary to a location in your PATH:
-   - **macOS/Linux**: `sudo mv twars-url2md /usr/local/bin/` or `mv twars-url2md ~/.local/bin/`
-   - **Windows**: Move to a folder in your PATH or add the folder to your PATH
-
-### 3.2. Install from Crates.io
-
-If you have Rust installed (version 1.70.0 or later), you can install directly from crates.io:
-
-```bash
-cargo install twars-url2md
-```
-
-### 3.3. Build from Source
-
-For the latest version or to customize the build:
-
-```bash
-# Clone the repository
-git clone https://github.com/twardoch/twars-url2md.git
-cd twars-url2md
-
-# Build and install
-cargo build --release
-mv target/release/twars-url2md /usr/local/bin/  # or any location in your PATH
-```
-
-## 4. Usage
-
-### 4.1. Command Line Options
-
-```
-Usage: twars-url2md [OPTIONS]
-
-Options:
-  -i, --input <FILE>       Input file containing URLs or local file paths (one per line)
-  -o, --output <DIR>       Output directory for markdown files
-      --stdin              Read URLs from standard input
-      --base-url <URL>     Base URL for resolving relative links
-  -p, --pack <FILE>        Output file to pack all markdown files together
-  -v, --verbose            Enable verbose output
-  -h, --help               Print help
-  -V, --version            Print version
-```
-
-### 4.2. Input Options
-
-The tool accepts URLs and local file paths from:
-
-- A file specified with `--input`
-- Standard input with `--stdin`
-- **Note:** Either `--input` or `--stdin` must be specified
-
-### 4.3. Output Options
-
-- `--output <DIR>`: Create individual Markdown files in this directory
-- `--pack <FILE>`: Combine all Markdown files into a single output file
-- You can use both options together
-
-### 4.4. Processing Local Files
-
-You can now include local HTML files in your input:
-
-- Absolute paths: `/path/to/file.html`
-- File URLs: `file:///path/to/file.html`
-- Mix of local files and remote URLs in the same input
-
-## 5. Examples
-
-### 5.1. Basic Usage
-
-```bash
-# Process a single URL and print to stdout
-echo "https://example.com" | twars-url2md --stdin
-
-# Process URLs from a file with specific output directory
-twars-url2md --input urls.txt --output ./markdown_output
-
-# Process piped URLs with base URL for relative links
-cat urls.txt | twars-url2md --stdin --base-url "https://example.com" --output ./output
-
-# Show verbose output
-twars-url2md --input urls.txt --output ./output --verbose
-```
-
-### 5.2. Using the Pack Option
-
-```bash
-# Process URLs and create a combined Markdown file
-twars-url2md --input urls.txt --pack combined.md
-
-# Both individual files and a combined file
-twars-url2md --input urls.txt --output ./output --pack combined.md
-```
-
-### 5.3. Processing Local Files
-
-```bash
-# Create a test HTML file
-echo "<html><body><h1>Test</h1><p>Content</p></body></html>" > test.html
-
-# Process a local HTML file
-echo "$PWD/test.html" > local_paths.txt
-twars-url2md --input local_paths.txt --output ./output
-
-# Mix local and remote content
-cat > mixed.txt << EOF
-https://example.com
-file://$PWD/test.html
-EOF
-twars-url2md --input mixed.txt --pack combined.md
-```
-
-### 5.4. Batch Processing
-
-```bash
-# Extract and process links from a webpage
-curl "https://en.wikipedia.org/wiki/Rust_(programming_language)" | twars-url2md --stdin --output rust_wiki/
-
-# Process multiple files
-find ./html_files -name "*.html" > files_to_process.txt
-twars-url2md --input files_to_process.txt --output ./markdown_output --pack all_content.md
-```
-
-## 6. Output Organization
-
-The tool organizes output into a directory structure based on the URLs:
-
-```
-output/
-├── example.com/
-│   ├── index.md       # from https://example.com/
-│   └── articles/
-│       └── page.md    # from https://example.com/articles/page
-└── another-site.com/
-    └── post/
-        └── article.md # from https://another-site.com/post/article
-```
-
-For local files, the directory structure mirrors the file path.
-
-## 7. Development
-
-### 7.1. Running Tests
-
-```bash
-# Run all tests
-cargo test
-
-# Run with specific features
-cargo test --all-features
-
-# Run specific test
-cargo test test_name
-```
-
-### 7.2. Code Quality Tools
-
-- **Formatting**: `cargo fmt`
-- **Linting**: `cargo clippy --all-targets --all-features`
-
-### 7.3. Publishing
-
-To publish a new release of twars-url2md:
-
-#### 7.3.1. Prepare for Release
-
-```bash
-# Update version in Cargo.toml (e.g. from 1.3.6 to 1.3.7)
-# Ensure everything works
-cargo test
-cargo clippy --all-targets --all-features
-cargo fmt --check
-```
-
-#### 7.3.2. Build Locally
-
-```bash
-# Build in release mode
-cargo build --release
-
-# Test the binary
-./target/release/twars-url2md --help
-```
-
-#### 7.3.3. Publish to Crates.io
-
-```bash
-# Login to crates.io (if not already logged in)
-cargo login
-
-# Verify the package
-cargo package
-
-# Publish
-cargo publish
-```
-
-#### 7.3.4. Create GitHub Release
-
-```bash
-# Create and push a tag matching your version
-git tag -a v1.3.7 -m "Release v1.3.7"
-git push origin v1.3.7
-```
-
-The configured GitHub Actions workflow (`.github/workflows/ci.yml`) will automatically:
-- Run tests on the tag
-- Create a GitHub Release
-- Build binaries for macOS, Windows, and Linux
-- Upload the binaries to the release
-- Publish to crates.io
-
-#### 7.3.5. Manual Release (Alternative)
-
-If GitHub Actions fails, you can create the release manually:
-
-1. Go to GitHub repository → Releases → Create a new release
-2. Select your tag
-3. Build platform-specific binaries:
-
-```bash
-# macOS universal binary
-cargo build --release --target x86_64-apple-darwin
-cargo build --release --target aarch64-apple-darwin
-lipo "target/x86_64-apple-darwin/release/twars-url2md" "target/aarch64-apple-darwin/release/twars-url2md" -create -output "target/twars-url2md"
-tar czf twars-url2md-macos-universal.tar.gz -C target twars-url2md
-
-# Linux
-cargo build --release --target x86_64-unknown-linux-gnu
-tar czf twars-url2md-linux-x86_64.tar.gz -C target/x86_64-unknown-linux-gnu/release twars-url2md
-
-# Windows
-cargo build --release --target x86_64-pc-windows-msvc
-cd target/x86_64-pc-windows-msvc/release
-7z a ../../../twars-url2md-windows-x86_64.zip twars-url2md.exe
-```
-
-4. Upload these files to your GitHub release
-
-#### 7.3.6. Verify the Release
-
-- Check that the release appears on GitHub
-- Verify that binary files are attached to the release
-- Confirm the new version appears on crates.io
-- Try installing the new version: `cargo install twars-url2md`
-
-## 8. License
-
-MIT License - see [LICENSE](LICENSE) for details.
-
-## 9. Author
-
-Adam Twardoch ([@twardoch](https://github.com/twardoch))
-
----
-
-For bug reports, feature requests, or general questions, please open an issue on the [GitHub repository](https://github.com/twardoch/twars-url2md/issues).
 </file>
 
 <file path="src/html.rs">
@@ -4381,6 +1437,278 @@ mod tests {
 }
 </file>
 
+<file path="src/lib.rs">
+use crate::url::Url;
+use anyhow::Result;
+use futures::stream::{self, StreamExt};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::thread;
+
+pub mod cli;
+// mod error; // Removed
+mod html;
+mod markdown;
+pub mod url;
+
+pub use cli::Cli;
+// pub use error::Error; // Removed
+
+include!(concat!(env!("OUT_DIR"), "/built.rs"));
+
+/// Version information with build details
+pub fn version() -> String {
+    format!(
+        "{}\nBuild Time: {}\nTarget: {}\nProfile: {}",
+        env!("CARGO_PKG_VERSION"),
+        BUILT_TIME_UTC,
+        TARGET,
+        PROFILE
+    )
+}
+
+/// Default user agent string for HTTP requests
+pub(crate) const USER_AGENT_STRING: &str =
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+/// Configuration for URL processing
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub verbose: bool,
+    pub max_retries: u32,
+    pub output_base: PathBuf,
+    pub single_file: bool,
+    pub has_output: bool,
+    pub pack_file: Option<PathBuf>,
+}
+
+/// Process a list of URLs with the given configuration
+pub async fn process_urls(
+    urls: Vec<String>,
+    config: Config,
+) -> Result<Vec<(String, anyhow::Error)>> {
+    use indicatif::{ProgressBar, ProgressStyle};
+    use tokio::io::AsyncWriteExt;
+
+    let pb = if urls.len() > 1 {
+        let pb = ProgressBar::new(urls.len() as u64);
+        let style = ProgressStyle::default_bar()
+            .template(
+                "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} ({eta})",
+            )
+            .map_err(|e| {
+                tracing::warn!(
+                    "Failed to create progress bar template: {}. Using default style.",
+                    e
+                )
+            })
+            .unwrap_or_else(|_| ProgressStyle::default_bar()) // Fallback to default style
+            .progress_chars("#>-");
+        pb.set_style(style);
+        Some(pb)
+    } else {
+        None
+    };
+
+    let pb = Arc::new(pb);
+    // Adaptive concurrency based on CPU cores
+    let concurrency_limit = thread::available_parallelism()
+        .map(|n| n.get() * 2) // 2 tasks per CPU core
+        .unwrap_or(10);
+    tracing::debug!("Concurrency limit set to: {}", concurrency_limit);
+
+    // If pack_file is specified, collect the markdown content
+    let should_pack = config.pack_file.is_some();
+    let pack_path = config.pack_file.clone();
+    let packed_content = if should_pack {
+        tracing::debug!("Packing mode enabled. Output will be: {:?}", pack_path);
+        Arc::new(tokio::sync::Mutex::new(Vec::with_capacity(urls.len())))
+    } else {
+        Arc::new(tokio::sync::Mutex::new(Vec::new())) // Empty vec if not packing
+    };
+
+    // Clone the URLs vector before moving it into the stream for ordering packed content later
+    let urls_for_ordering = if should_pack {
+        urls.clone()
+    } else {
+        Vec::new()
+    };
+
+    let results = stream::iter(urls.into_iter().map(|url_str| {
+        let pb_clone = Arc::clone(&pb);
+        let config_clone = config.clone();
+        let packed_content_clone = Arc::clone(&packed_content);
+        async move {
+            tracing::info!("Processing URL: {}", url_str);
+            match Url::parse(&url_str) {
+                Ok(url_parsed) => {
+                    let out_path = if config_clone.single_file
+                        && config_clone.has_output
+                        && !config_clone.output_base.is_dir()
+                    {
+                        Some(config_clone.output_base)
+                    } else {
+                        match url::create_output_path(&url_parsed, &config_clone.output_base) {
+                            Ok(p) => Some(p),
+                            Err(e) => {
+                                tracing::error!("Failed to create output path for {}: {}", url_str, e);
+                                None
+                            }
+                        }
+                    };
+                    tracing::debug!("Output path for {}: {:?}", url_str, out_path);
+
+                    let result = if should_pack {
+                        // Process URL and collect content for packing
+                        // Calls html::process_url_content_with_retry now
+                        match html::process_url_content_with_retry(
+                            &url_str,
+                            out_path,
+                            config_clone.max_retries,
+                        )
+                        .await
+                        {
+                            Ok(content_opt) => {
+                                if let Some(md_content) = content_opt {
+                                    // md_content will be empty if it's a real empty page,
+                                    // content_opt will be None if it was a non-HTML skip.
+                                    // The packing logic should only add non-empty actual content.
+                                    // The current check `if !md_content.is_empty()` is correct.
+                                    if !md_content.is_empty() {
+                                        let mut content_vec = packed_content_clone.lock().await;
+                                        content_vec.push((url_str.clone(), md_content));
+                                        tracing::debug!("Collected content for packing for URL: {}", url_str);
+                                    } else {
+                                        tracing::debug!("Content for URL {} is empty, not packing. (Could be actual empty page or handled skip)", url_str);
+                                    }
+                                } else {
+                                     tracing::debug!("URL {} was skipped (e.g. non-HTML), no content to pack.", url_str);
+                                }
+                                Ok(())
+                            }
+                            Err(e) => {
+                                tracing::warn!("Failed to process and get content for {}: {}", url_str, e.1);
+                                Err(e)
+                            }
+                        }
+                    } else {
+                        // Process URL normally (writes to file or stdout via process_url_async)
+                        // Calls html::process_url_with_retry now
+                        html::process_url_with_retry(
+                            &url_str,
+                            out_path,
+                            config_clone.max_retries,
+                        )
+                        .await
+                    };
+
+                    if let Some(pb_instance) = &*pb_clone {
+                        pb_instance.inc(1);
+                    }
+                    result
+                }
+                Err(e) => {
+                    tracing::error!("Failed to parse URL {}: {}", url_str, e);
+                    if let Some(pb_instance) = &*pb_clone {
+                        pb_instance.inc(1);
+                    }
+                    Err((url_str, e.into()))
+                }
+            }
+        }
+    }))
+    .buffer_unordered(concurrency_limit)
+    .collect::<Vec<_>>()
+    .await;
+
+    if let Some(pb_instance) = &*pb {
+        pb_instance.finish_with_message("Processing complete!");
+        // pb_instance.finish_and_clear(); // Optionally clear the progress bar
+    }
+
+    // Write the packed content to the specified file
+    if let Some(path) = pack_path {
+        tracing::info!("Writing packed content to {}", path.display());
+
+        if let Some(parent) = path.parent() {
+            if !parent.exists() {
+                tracing::debug!(
+                    "Creating parent directory for packed file: {}",
+                    parent.display()
+                );
+                if let Err(e) = tokio::fs::create_dir_all(parent).await {
+                    tracing::error!(
+                        "Failed to create directory {} for packed file: {}",
+                        parent.display(),
+                        e
+                    );
+                    // Continue to attempt writing, but log the error.
+                }
+            }
+        }
+
+        let mut packed_file = match tokio::fs::File::create(&path).await {
+            Ok(file) => file,
+            Err(e) => {
+                tracing::error!(
+                    "Fatal: Error creating packed file {}: {}",
+                    path.display(),
+                    e
+                );
+                // Collect all errors from processing and return them
+                return Ok(results.into_iter().filter_map(|r| r.err()).collect());
+            }
+        };
+
+        // Get the locked packed_content
+        let mut content_to_write = packed_content.lock().await;
+
+        // Reorder packed_content to match the original URL order
+        if !urls_for_ordering.is_empty() {
+            let mut url_to_index = std::collections::HashMap::new();
+            for (i, u) in urls_for_ordering.iter().enumerate() {
+                url_to_index.insert(u.clone(), i);
+            }
+
+            content_to_write.sort_by(|a, b| {
+                let a_idx = url_to_index.get(&a.0).unwrap_or(&usize::MAX);
+                let b_idx = url_to_index.get(&b.0).unwrap_or(&usize::MAX);
+                a_idx.cmp(b_idx)
+            });
+            tracing::debug!("Packed content reordered according to input URL order.");
+        }
+
+        for (url_str, content) in content_to_write.iter() {
+            let formatted_entry = format!("# {}\n\n{}\n\n---\n\n", url_str, content);
+            if let Err(e) = packed_file.write_all(formatted_entry.as_bytes()).await {
+                tracing::error!(
+                    "Error writing entry for {} to packed file {}: {}",
+                    url_str,
+                    path.display(),
+                    e
+                );
+            }
+        }
+        tracing::info!(
+            "Successfully wrote {} entries to packed file {}",
+            content_to_write.len(),
+            path.display()
+        );
+    }
+
+    // Collect and return errors
+    let mut errors = Vec::new();
+    for r in results {
+        if let Err(e) = r {
+            // Error already logged at source, just collect for summary
+            errors.push(e);
+        }
+    }
+
+    Ok(errors)
+}
+</file>
+
 <file path="src/main.rs">
 use anyhow::Result;
 use std::panic;
@@ -4484,6 +1812,2641 @@ fn main() {
 }
 </file>
 
+<file path="src/markdown.rs">
+use anyhow::{Context, Result};
+
+/// Convert HTML to Markdown
+pub fn convert_html_to_markdown(html: &str) -> Result<String> {
+    htmd::convert(html).context("Failed to convert HTML to Markdown")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_convert_html_to_markdown() -> Result<()> {
+        let html = r#"
+            <html>
+                <body>
+                    <h1>Test</h1>
+                    <p>Hello, world!</p>
+                </body>
+            </html>
+        "#;
+
+        let markdown = convert_html_to_markdown(html)?;
+        assert!(markdown.contains("# Test"));
+        assert!(markdown.contains("Hello, world!"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_heading_levels() -> Result<()> {
+        let html = r#"
+            <h1>Level 1</h1>
+            <h2>Level 2</h2>
+            <h3>Level 3</h3>
+            <h4>Level 4</h4>
+            <h5>Level 5</h5>
+            <h6>Level 6</h6>
+        "#;
+
+        let markdown = convert_html_to_markdown(html)?;
+        assert!(markdown.contains("# Level 1"));
+        assert!(markdown.contains("## Level 2"));
+        assert!(markdown.contains("### Level 3"));
+        assert!(markdown.contains("#### Level 4"));
+        assert!(markdown.contains("##### Level 5"));
+        assert!(markdown.contains("###### Level 6"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_text_formatting() -> Result<()> {
+        let html = r#"
+            <p>Text with <strong>bold</strong> and <em>italic</em> and <code>code</code>.</p>
+            <p>Also <b>bold tag</b> and <i>italic tag</i>.</p>
+        "#;
+
+        let markdown = convert_html_to_markdown(html)?;
+        assert!(markdown.contains("**bold**"));
+        assert!(markdown.contains("*italic*") || markdown.contains("_italic_"));
+        assert!(markdown.contains("`code`"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_lists() -> Result<()> {
+        let html = r#"
+            <ul>
+                <li>Unordered 1</li>
+                <li>Unordered 2</li>
+            </ul>
+            <ol>
+                <li>Ordered 1</li>
+                <li>Ordered 2</li>
+            </ol>
+        "#;
+
+        let markdown = convert_html_to_markdown(html)?;
+        // htmd might use different list markers
+        assert!(markdown.contains("Unordered 1"));
+        assert!(markdown.contains("Unordered 2"));
+        assert!(markdown.contains("Ordered 1"));
+        assert!(markdown.contains("Ordered 2"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_links_and_images() -> Result<()> {
+        let html = r#"
+            <p>Visit <a href="https://example.com">Example Site</a>.</p>
+            <p><img src="test.jpg" alt="Test Image" /></p>
+        "#;
+
+        let markdown = convert_html_to_markdown(html)?;
+        assert!(markdown.contains("[Example Site](https://example.com)"));
+        assert!(markdown.contains("![Test Image](test.jpg)"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_blockquotes() -> Result<()> {
+        let html = r#"
+            <blockquote>
+                <p>This is a quote.</p>
+            </blockquote>
+        "#;
+
+        let markdown = convert_html_to_markdown(html)?;
+        assert!(markdown.contains("> This is a quote."));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_code_blocks() -> Result<()> {
+        let html = r#"
+            <pre><code>fn main() {
+    println!("Hello");
+}</code></pre>
+        "#;
+
+        let markdown = convert_html_to_markdown(html)?;
+        assert!(markdown.contains("```") || markdown.contains("    fn main()"));
+        assert!(markdown.contains("println!"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_horizontal_rule() -> Result<()> {
+        let html = r#"
+            <p>Before</p>
+            <hr>
+            <p>After</p>
+        "#;
+
+        let markdown = convert_html_to_markdown(html)?;
+        // htmd might render hr differently, just check both paragraphs are present
+        assert!(markdown.contains("Before"));
+        assert!(markdown.contains("After"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_empty_elements() -> Result<()> {
+        let html = r#"
+            <p></p>
+            <div></div>
+            <h1></h1>
+        "#;
+
+        let markdown = convert_html_to_markdown(html)?;
+        // Should handle empty elements without crashing
+        assert!(markdown.is_empty() || markdown.trim().is_empty() || markdown.len() < 10);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_nested_formatting() -> Result<()> {
+        let html = r#"
+            <p>Text with <strong>bold and <em>italic</em></strong> combined.</p>
+        "#;
+
+        let markdown = convert_html_to_markdown(html)?;
+        assert!(markdown.contains("bold"));
+        assert!(markdown.contains("italic"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_special_characters() -> Result<()> {
+        let html = r#"
+            <p>Special: &lt; &gt; &amp; &quot;</p>
+        "#;
+
+        let markdown = convert_html_to_markdown(html)?;
+        assert!(markdown.contains("<"));
+        assert!(markdown.contains(">"));
+        assert!(markdown.contains("&"));
+        assert!(markdown.contains("\""));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_script_style_removal() -> Result<()> {
+        let html = r#"
+            <html>
+                <head>
+                    <script>console.log('test');</script>
+                    <style>body { color: red; }</style>
+                </head>
+                <body>
+                    <p>Actual content</p>
+                </body>
+            </html>
+        "#;
+
+        let markdown = convert_html_to_markdown(html)?;
+        // htmd might include script/style content, just verify the main content is there
+        assert!(markdown.contains("Actual content"));
+        // Verify it's not excessively long (scripts/styles might make it longer)
+        assert!(markdown.len() < 500);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_table_conversion() -> Result<()> {
+        let html = r#"
+            <table>
+                <tr>
+                    <th>Header 1</th>
+                    <th>Header 2</th>
+                </tr>
+                <tr>
+                    <td>Cell 1</td>
+                    <td>Cell 2</td>
+                </tr>
+            </table>
+        "#;
+
+        let markdown = convert_html_to_markdown(html)?;
+        // Tables might be converted differently by htmd
+        assert!(markdown.contains("Header 1"));
+        assert!(markdown.contains("Header 2"));
+        assert!(markdown.contains("Cell 1"));
+        assert!(markdown.contains("Cell 2"));
+
+        Ok(())
+    }
+}
+</file>
+
+<file path="src/url.rs">
+use anyhow::{Context, Result};
+use html5ever::parse_document;
+use html5ever::tendril::TendrilSink;
+use linkify::{LinkFinder, LinkKind};
+use markup5ever_rcdom as rcdom;
+// anyhow::Context is already imported via `use anyhow::{Context, Result};`
+// use rayon::prelude::*; // No longer used after removing extract_urls_from_html_efficient
+use regex;
+use std::path::{Path, PathBuf};
+pub use url::Url;
+
+/// Create an output path for a URL based on its structure
+pub fn create_output_path(url: &Url, base_dir: &Path) -> Result<PathBuf> {
+    let host = url.host_str().unwrap_or("unknown");
+
+    let path_segments: Vec<_> = url.path().split('/').filter(|s| !s.is_empty()).collect();
+
+    // Build the directory path, including trailing-segment directories if the URL ends with '/'
+    let mut dir_path_full = base_dir.join(host);
+
+    // Decide which segments belong to directories vs. filename
+    let segments_for_dirs: &[&str] = if path_segments.is_empty() {
+        &[]
+    } else if url.path().ends_with('/') {
+        // All segments are directories when URL ends with '/'
+        &path_segments[..]
+    } else {
+        // All except the last segment represent directories
+        &path_segments[..path_segments.len() - 1]
+    };
+
+    for segment in segments_for_dirs {
+        dir_path_full = dir_path_full.join(segment);
+    }
+
+    // Ensure directories exist on disk
+    std::fs::create_dir_all(&dir_path_full)
+        .with_context(|| format!("Failed to create directory: {}", dir_path_full.display()))?;
+
+    // Determine filename
+    let filename = if url.path().ends_with('/') || path_segments.is_empty() {
+        "index.md".to_string()
+    } else {
+        let last_segment = path_segments.last().unwrap();
+        Path::new(last_segment)
+            .file_stem()
+            .map(|s| format!("{}.md", s.to_string_lossy()))
+            .unwrap_or_else(|| format!("{}.md", last_segment))
+    };
+
+    Ok(dir_path_full.join(filename))
+}
+
+/// Extract URLs from any text input
+pub fn extract_urls_from_text(text: &str, base_url: Option<&str>) -> Vec<String> {
+    // Pre-allocate with a reasonable capacity based on text length
+    let estimated_capacity = text.len() / 100; // More conservative estimate
+    let mut urls = Vec::with_capacity(estimated_capacity.min(1000));
+
+    // Add logic to identify local file paths
+    // This regex is static and assumed to be valid. Panicking here is acceptable if it's malformed.
+    let file_regex = regex::Regex::new(r"^(file://)?(/[^/\s]+(?:/[^/\s]+)*\.html?)$")
+        .expect("Invalid static regex for file paths");
+
+    // Process text lines to extract URLs and local file paths
+    for line in text.lines() {
+        let line = line.trim();
+
+        // Check if line is a local file path
+        if file_regex.is_match(line) {
+            // Convert to file:// URL format if not already
+            let file_url = if line.starts_with("file://") {
+                line.to_string()
+            } else {
+                format!("file://{}", line)
+            };
+            urls.push(file_url);
+        } else if !line.is_empty() {
+            // Process as regular URL
+            process_text_chunk(line, base_url, &mut urls);
+        }
+    }
+
+    // Use unstable sort for better performance since order doesn't matter for deduplication
+    urls.sort_unstable();
+    urls.dedup();
+    urls
+}
+
+/// Process a chunk of text to extract URLs
+fn process_text_chunk(text: &str, base_url: Option<&str>, urls: &mut Vec<String>) {
+    let trimmed_text = text.trim();
+    if trimmed_text.starts_with('<') {
+        // Attempt to parse as HTML if it looks like an HTML tag/document fragment
+        match extract_urls_from_html(trimmed_text, base_url) {
+            Ok(extracted) => {
+                urls.extend(extracted);
+            }
+            Err(e) => {
+                // Log the error and fall back to simple LinkFinder for this chunk
+                tracing::debug!(
+                    "Failed to parse text chunk as HTML ({}): '{}...'. Falling back to LinkFinder.",
+                    e,
+                    trimmed_text.chars().take(50).collect::<String>()
+                );
+                let finder = LinkFinder::new();
+                urls.extend(finder.links(trimmed_text).filter_map(|link| {
+                    if link.kind() == &LinkKind::Url {
+                        try_parse_url(link.as_str(), base_url)
+                    } else {
+                        None
+                    }
+                }));
+            }
+        }
+    } else {
+        // Standard LinkFinder for non-HTML-like text
+        let finder = LinkFinder::new();
+        urls.extend(finder.links(trimmed_text).filter_map(|link| {
+            if link.kind() == &LinkKind::Url {
+                try_parse_url(link.as_str(), base_url)
+            } else {
+                None
+            }
+        }));
+    }
+}
+
+// Removed extract_urls_from_html_efficient.
+// Its logic will be integrated into process_text_chunk's fallback,
+// and extract_urls_from_html is the primary method for HTML content.
+
+/// Extract URLs from HTML content, including attributes and text content
+pub fn extract_urls_from_html(html: &str, base_url: Option<&str>) -> Result<Vec<String>> {
+    let mut urls = Vec::new();
+
+    // Parse HTML document
+    let dom = parse_document(rcdom::RcDom::default(), Default::default())
+        .from_utf8()
+        .read_from(&mut html.as_bytes())
+        .map_err(|e| anyhow::anyhow!("Failed to parse HTML for URL extraction: {}", e))?;
+
+    // Extract URLs from HTML structure using iterative approach
+    let mut stack = vec![dom.document.clone()];
+    while let Some(node) = stack.pop() {
+        // Process element nodes
+        if let rcdom::NodeData::Element { ref attrs, .. } = node.data {
+            let attrs = attrs.borrow();
+
+            // Define URL-containing attributes to check
+            let url_attrs = ["href", "src", "data-src", "data-href", "data-url"];
+
+            for attr in attrs.iter() {
+                let attr_name = attr.name.local.to_string();
+                let attr_value = attr.value.to_string();
+
+                if url_attrs.contains(&attr_name.as_str()) {
+                    if let Some(url) = try_parse_url(&attr_value, base_url) {
+                        urls.push(url);
+                    }
+                } else if attr_name == "srcset" {
+                    // Handle srcset attribute which may contain multiple URLs
+                    for src in attr_value.split(',') {
+                        let src = src.split_whitespace().next().unwrap_or("");
+                        if let Some(url) = try_parse_url(src, base_url) {
+                            urls.push(url);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Add child nodes to stack
+        for child in node.children.borrow().iter() {
+            stack.push(child.clone());
+        }
+    }
+
+    // Use LinkFinder as a fallback to catch any remaining URLs in text content
+    let finder = LinkFinder::new();
+    for link in finder.links(html) {
+        if link.kind() == &LinkKind::Url {
+            if let Some(url) = try_parse_url(link.as_str(), base_url) {
+                urls.push(url);
+            }
+        }
+    }
+
+    // Deduplicate and sort URLs
+    urls.sort();
+    urls.dedup();
+    Ok(urls)
+}
+
+fn try_parse_url(url_str: &str, base_url: Option<&str>) -> Option<String> {
+    // Skip obvious non-URLs
+    if url_str.trim().is_empty()
+        || url_str.starts_with("data:")
+        || url_str.starts_with("javascript:")
+        || url_str.starts_with('#')
+        || url_str.contains('{')
+        || url_str.contains('}')
+        || url_str.contains('(')
+        || url_str.contains(')')
+        || url_str.contains('[')
+        || url_str.contains(']')
+        || url_str.contains('<')
+        || url_str.contains('>')
+        || url_str.contains('"')
+        || url_str.contains('\'')
+        || url_str.contains('`')
+        || url_str.contains('\n')
+        || url_str.contains('\r')
+        || url_str.contains('\t')
+        || url_str.contains(' ')
+    {
+        return None;
+    }
+
+    // Handle file:// URLs
+    if url_str.starts_with("file://") {
+        return Some(url_str.to_string());
+    }
+
+    // Check if it could be a local file path
+    if url_str.starts_with('/') && Path::new(url_str).exists() {
+        return Some(format!("file://{}", url_str));
+    }
+
+    // Try parsing as absolute URL first
+    if let Ok(url) = Url::parse(url_str) {
+        if url.scheme() == "http" || url.scheme() == "https" {
+            // Normalize: drop trailing slash for bare domain URLs ("https://example.com/")
+            let mut normalized = url.to_string();
+            if url.path() == "/" && url.query().is_none() && url.fragment().is_none() {
+                normalized.pop(); // remove the trailing '/'
+            }
+            return Some(normalized);
+        }
+    }
+
+    // If we have a base URL and the input looks like a relative URL, try joining
+    if let Some(base) = base_url {
+        if let Ok(base_url) = Url::parse(base) {
+            if let Ok(url) = base_url.join(url_str) {
+                if url.scheme() == "http" || url.scheme() == "https" {
+                    return Some(url.to_string());
+                }
+            }
+        }
+    }
+
+    None
+}
+
+// process_url_with_retry and process_url_with_content (with retry logic)
+// have been moved to src/html.rs and made pub(crate) there.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_extract_urls_from_text() {
+        let text = r#"
+            https://example.com
+            http://test.org
+            Invalid: ftp://example.com
+            https://example.com/path?query=value#fragment
+        "#;
+
+        let urls = extract_urls_from_text(text, None);
+        assert_eq!(urls.len(), 3);
+        assert!(urls.iter().any(|u| u.starts_with("https://example.com")));
+        assert!(urls.iter().any(|u| u.starts_with("http://test.org")));
+    }
+
+    #[tokio::test]
+    async fn test_create_output_path() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+
+        let url = Url::parse("https://example.com/path/page")?;
+        let path = create_output_path(&url, temp_dir.path())?;
+
+        assert!(path.starts_with(temp_dir.path()));
+        assert!(path.to_string_lossy().contains("example.com"));
+        assert!(path.to_string_lossy().ends_with(".md"));
+
+        Ok(())
+    }
+}
+</file>
+
+<file path="test_output/example.com/index.md">
+Example Domain
+
+# Example Domain
+
+This domain is for use in illustrative examples in documents. You may use this domain in literature without prior coordination or asking for permission.
+
+[More information...](https://www.iana.org/domains/example)
+</file>
+
+<file path="testdata/example.sh">
+#!/usr/bin/env bash
+cd "$(dirname "$0")"
+
+echo "https://helpx.adobe.com/pl/indesign/using/using-fonts.html" | ../target/release/twars-url2md --stdin -o out "$@"
+</file>
+
+<file path="tests/integration/e2e_tests.rs">
+// this_file: tests/integration/e2e_tests.rs
+
+use anyhow::Result;
+use tempfile::TempDir;
+use twars_url2md::{process_urls, Config};
+
+#[cfg(test)]
+mod end_to_end_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_single_url_processing() -> Result<()> {
+        let _m = mockito::mock("GET", "/simple.html")
+            .with_status(200)
+            .with_header("content-type", "text/html")
+            .with_body(r#"
+                <html>
+                    <body>
+                        <h1>Simple Page</h1>
+                        <p>This is a simple test page.</p>
+                    </body>
+                </html>
+            "#)
+            .create();
+
+        let temp_dir = TempDir::new()?;
+        let url = format!("{}/simple.html", mockito::server_url());
+        
+        let config = Config {
+            verbose: false,
+            max_retries: 3,
+            output_base: temp_dir.path().to_path_buf(),
+            single_file: false,
+            has_output: true,
+            pack_file: None,
+        };
+
+        let errors = process_urls(vec![url.clone()], config).await?;
+        assert!(errors.is_empty());
+
+        // Check that the file was created
+        let host = mockito::server_url().replace("http://", "");
+        let expected_path = temp_dir.path().join(&host).join("simple.md");
+        assert!(expected_path.exists());
+
+        // Check content
+        let content = tokio::fs::read_to_string(&expected_path).await?;
+        assert!(content.contains("Simple Page"));
+        assert!(content.contains("simple test page"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_multiple_urls_processing() -> Result<()> {
+        let _m1 = mockito::mock("GET", "/page1.html")
+            .with_status(200)
+            .with_header("content-type", "text/html")
+            .with_body("<html><body><h1>Page 1</h1></body></html>")
+            .create();
+
+        let _m2 = mockito::mock("GET", "/page2.html")
+            .with_status(200)
+            .with_header("content-type", "text/html")
+            .with_body("<html><body><h1>Page 2</h1></body></html>")
+            .create();
+
+        let _m3 = mockito::mock("GET", "/page3.html")
+            .with_status(200)
+            .with_header("content-type", "text/html")
+            .with_body("<html><body><h1>Page 3</h1></body></html>")
+            .create();
+
+        let temp_dir = TempDir::new()?;
+        let urls = vec![
+            format!("{}/page1.html", mockito::server_url()),
+            format!("{}/page2.html", mockito::server_url()),
+            format!("{}/page3.html", mockito::server_url()),
+        ];
+
+        let config = Config {
+            verbose: false,
+            max_retries: 3,
+            output_base: temp_dir.path().to_path_buf(),
+            single_file: false,
+            has_output: true,
+            pack_file: None,
+        };
+
+        let errors = process_urls(urls, config).await?;
+        assert!(errors.is_empty());
+
+        // Check all files were created
+        let host = mockito::server_url().replace("http://", "");
+        for i in 1..=3 {
+            let path = temp_dir.path().join(&host).join(format!("page{}.md", i));
+            assert!(path.exists());
+            let content = tokio::fs::read_to_string(&path).await?;
+            assert!(content.contains(&format!("Page {}", i)));
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_packed_output() -> Result<()> {
+        let _m1 = mockito::mock("GET", "/doc1.html")
+            .with_status(200)
+            .with_header("content-type", "text/html")
+            .with_body("<html><body><h1>Document 1</h1><p>Content 1</p></body></html>")
+            .create();
+
+        let _m2 = mockito::mock("GET", "/doc2.html")
+            .with_status(200)
+            .with_header("content-type", "text/html")
+            .with_body("<html><body><h1>Document 2</h1><p>Content 2</p></body></html>")
+            .create();
+
+        let temp_dir = TempDir::new()?;
+        let pack_file = temp_dir.path().join("packed.md");
+        let urls = vec![
+            format!("{}/doc1.html", mockito::server_url()),
+            format!("{}/doc2.html", mockito::server_url()),
+        ];
+
+        let config = Config {
+            verbose: false,
+            max_retries: 3,
+            output_base: temp_dir.path().to_path_buf(),
+            single_file: false,
+            has_output: true,
+            pack_file: Some(pack_file.clone()),
+        };
+
+        let errors = process_urls(urls, config).await?;
+        assert!(errors.is_empty());
+
+        // Check packed file exists and contains both documents
+        assert!(pack_file.exists());
+        let content = tokio::fs::read_to_string(&pack_file).await?;
+        assert!(content.contains("Document 1"));
+        assert!(content.contains("Content 1"));
+        assert!(content.contains("Document 2"));
+        assert!(content.contains("Content 2"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_error_handling() -> Result<()> {
+        let _m = mockito::mock("GET", "/error.html")
+            .with_status(500)
+            .with_body("Internal Server Error")
+            .expect(4) // Initial try + 3 retries
+            .create();
+
+        let temp_dir = TempDir::new()?;
+        let url = format!("{}/error.html", mockito::server_url());
+
+        let config = Config {
+            verbose: false,
+            max_retries: 3,
+            output_base: temp_dir.path().to_path_buf(),
+            single_file: false,
+            has_output: true,
+            pack_file: None,
+        };
+
+        let errors = process_urls(vec![url.clone()], config).await?;
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].0, url);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_mixed_success_and_failure() -> Result<()> {
+        let _m1 = mockito::mock("GET", "/success.html")
+            .with_status(200)
+            .with_header("content-type", "text/html")
+            .with_body("<html><body><h1>Success</h1></body></html>")
+            .create();
+
+        let _m2 = mockito::mock("GET", "/failure.html")
+            .with_status(404)
+            .expect(4) // Initial try + 3 retries
+            .create();
+
+        let temp_dir = TempDir::new()?;
+        let urls = vec![
+            format!("{}/success.html", mockito::server_url()),
+            format!("{}/failure.html", mockito::server_url()),
+        ];
+
+        let config = Config {
+            verbose: false,
+            max_retries: 3,
+            output_base: temp_dir.path().to_path_buf(),
+            single_file: false,
+            has_output: true,
+            pack_file: None,
+        };
+
+        let errors = process_urls(urls.clone(), config).await?;
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].0.contains("failure.html"));
+
+        // Success file should exist
+        let host = mockito::server_url().replace("http://", "");
+        let success_path = temp_dir.path().join(&host).join("success.md");
+        assert!(success_path.exists());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_single_file_output() -> Result<()> {
+        let _m = mockito::mock("GET", "/content.html")
+            .with_status(200)
+            .with_header("content-type", "text/html")
+            .with_body("<html><body><h1>Content</h1></body></html>")
+            .create();
+
+        let temp_dir = TempDir::new()?;
+        let output_file = temp_dir.path().join("output.md");
+        let url = format!("{}/content.html", mockito::server_url());
+
+        let config = Config {
+            verbose: false,
+            max_retries: 3,
+            output_base: output_file.clone(),
+            single_file: true,
+            has_output: true,
+            pack_file: None,
+        };
+
+        let errors = process_urls(vec![url], config).await?;
+        assert!(errors.is_empty());
+
+        // Check file was created at specified path
+        assert!(output_file.exists());
+        let content = tokio::fs::read_to_string(&output_file).await?;
+        assert!(content.contains("Content"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_non_html_content_skipped() -> Result<()> {
+        let urls = vec![
+            "https://example.com/image.jpg".to_string(),
+            "https://example.com/document.pdf".to_string(),
+            "https://example.com/video.mp4".to_string(),
+        ];
+
+        let temp_dir = TempDir::new()?;
+        let config = Config {
+            verbose: false,
+            max_retries: 3,
+            output_base: temp_dir.path().to_path_buf(),
+            single_file: false,
+            has_output: true,
+            pack_file: None,
+        };
+
+        // These should be skipped without errors
+        let _errors = process_urls(urls, config).await?;
+        
+        // No files should be created for non-HTML content
+        assert!(temp_dir.path().read_dir()?.next().is_none());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_local_file_processing() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let html_file = temp_dir.path().join("local.html");
+        tokio::fs::write(&html_file, "<html><body><h1>Local File</h1></body></html>").await?;
+
+        let url = format!("file://{}", html_file.display());
+        let output_dir = temp_dir.path().join("output");
+
+        let config = Config {
+            verbose: false,
+            max_retries: 3,
+            output_base: output_dir.clone(),
+            single_file: false,
+            has_output: true,
+            pack_file: None,
+        };
+
+        let errors = process_urls(vec![url], config).await?;
+        assert!(errors.is_empty());
+
+        // Check output was created
+        let output_files: Vec<_> = std::fs::read_dir(&output_dir)?
+            .filter_map(|e| e.ok())
+            .collect();
+        assert!(!output_files.is_empty());
+
+        Ok(())
+    }
+}
+</file>
+
+<file path="tests/integration/mod.rs">
+// this_file: tests/integration/mod.rs
+
+pub mod e2e_tests;
+</file>
+
+<file path="tests/unit/mod.rs">
+// this_file: tests/unit/mod.rs
+
+pub mod url_tests;
+</file>
+
+<file path="tests/tests.rs">
+// this_file: tests/tests.rs
+
+mod unit;
+// mod integration; // Temporarily disabled due to mockito version incompatibility
+</file>
+
+<file path=".cursorrules">
+# https://github.com/twardoch/twars-url2md
+
+## 1. Project Overview
+
+`twars-url2md` is a Rust CLI application that downloads URLs and converts them to clean, readable Markdown files. It can extract URLs from various text formats and process them concurrently.
+
+## 2. Commands
+
+### 2.1. Development
+```bash
+# Run tests
+cargo test --all-features
+
+# Format code
+cargo fmt
+
+# Run linter
+cargo clippy --all-targets --all-features
+
+# Build release binary
+cargo build --release
+
+# Run with arguments
+cargo run -- [OPTIONS]
+```
+
+### 2.2. Publishing
+```bash
+# Verify package before publishing
+cargo package
+
+# Publish to crates.io
+cargo publish
+```
+
+## 3. Architecture
+
+The codebase follows a modular design with clear separation of concerns:
+
+- `src/main.rs` - Entry point with panic handling wrapper
+- `src/lib.rs` - Core processing logic and orchestration
+- `src/cli.rs` - Command-line interface using Clap
+- `src/url.rs` - URL extraction and validation logic
+- `src/html.rs` - HTML fetching and cleaning using Monolith
+- `src/markdown.rs` - HTML to Markdown conversion using htmd
+
+### 3.1. Key Design Decisions
+
+1. **Panic Recovery**: The application catches panics from the Monolith library to prevent crashes during HTML processing (see `src/main.rs:10-20`).
+
+2. **Concurrent Processing**: Uses Tokio with adaptive concurrency based on available CPUs for parallel URL processing (see `src/lib.rs:107-120`).
+
+3. **Error Handling**: Uses `anyhow` for error propagation with custom error types and retry logic for network failures.
+
+4. **Output Organization**: Generates file paths based on URL structure when using `-o` option, creating a repository-like structure.
+
+## 4. Testing
+
+Run tests with `cargo test --all-features`. The test module is in `src/tests.rs` and includes unit tests for URL extraction and processing logic.
+
+## 5. Dependencies
+
+- **Async Runtime**: tokio with full features
+- **HTTP Client**: reqwest with vendored OpenSSL
+- **HTML Processing**: monolith for cleaning, htmd for Markdown conversion
+- **CLI**: clap with derive feature
+- **Utilities**: indicatif (progress bars), rayon (parallelism)
+
+## 6. Active Development
+
+See `TODO.md` for the modernization plan, which includes:
+- Migration from OpenSSL to rustls
+- Integration of structured logging with tracing
+- Enhanced error reporting
+- Performance optimizations
+
+When implementing new features, ensure compatibility with the async architecture and maintain the modular structure.
+
+# Working principles for software development
+
+## 7. When you write code (in any language)
+
+- Iterate gradually, avoiding major changes 
+- Minimize confirmations and checks
+- Preserve existing code/structure unless necessary
+- Use constants over magic numbers
+- Check for existing solutions in the codebase before starting
+- Check often the coherence of the code you’re writing with the rest of the code. 
+- Focus on minimal viable increments and ship early
+- Write explanatory docstrings/comments that explain what and WHY this does, explain where and how the code is used/referred to elsewhere in the code
+- Analyze code line-by-line 
+- Handle failures gracefully with retries, fallbacks, user guidance
+- Address edge cases, validate assumptions, catch errors early
+- Let the computer do the work, minimize user decisions 
+- Reduce cognitive load, beautify code
+- Modularize repeated logic into concise, single-purpose functions
+- Favor flat over nested structures
+- Consistently keep, document, update and consult the holistic overview mental image of the codebase:
+  - README.md (purpose and functionality) 
+  - CHANGELOG.md (past changes)
+  - TODO.md (future goals)
+  - PROGRESS.md (detailed flat task list)
+
+## 8. Use MCP tools if you can
+
+Before and during coding (if have access to tools), you should: 
+
+- consult the `context7` tool for most up-to-date software package documentation;
+- ask intelligent questions to the `deepseek/deepseek-r1-0528:free` model via the `chat_completion` tool to get additional reasoning;
+- also consult the `openai/o3` model via the `chat_completion` tool for additional reasoning and help with the task;
+- use the `sequentialthinking` tool to think about the best way to solve the task; 
+- use the `perplexity_ask` and `duckduckgo_web_search` tools to gather up-to-date information or context;
+
+## 9. Keep track of paths
+
+In each source file, maintain the up-to-date `this_file` record that shows the path of the current file relative to project root. Place the `this_file` record near the top of the file, as a comment after the shebangs, or in the YAML Markdown frontmatter. 
+
+## 10. If you write Python
+
+- PEP 8: Use consistent formatting and naming
+- Write clear, descriptive names for functions and variables
+- PEP 20: Keep code simple and explicit. Prioritize readability over cleverness
+- Use type hints in their simplest form (list, dict, | for unions)
+- PEP 257: Write clear, imperative docstrings
+- Use f-strings. Use structural pattern matching where appropriate
+- ALWAYS add "verbose" mode logugu-based logging, & debug-log
+- For CLI Python scripts, use fire & rich, and start the script with 
+
+```
+#!/usr/bin/env -S uv run -s
+# /// script
+# dependencies = ["PKG1", "PKG2"]
+# ///
+# this_file: PATH_TO_CURRENT_FILE
+```
+
+After Python changes run:
+
+```
+uzpy run .; fd -e py -x autoflake {}; fd -e py -x pyupgrade --py312-plus {}; fd -e py -x ruff check --output-format=github --fix --unsafe-fixes {}; fd -e py -x ruff format --respect-gitignore --target-version py312 {}; python -m pytest;
+```
+
+## 11. Additional guidelines
+
+Ask before extending/refactoring existing code in a way that may add complexity or break things. 
+
+When you’re finished, print "Wait, but" to go back, think & reflect, revise & improvement what you’ve done (but don’t invent functionality freely). Repeat this. But stick to the goal of "minimal viable next version". 
+
+## 12. Virtual team work
+
+Be creative, diligent, critical, relentless & funny! Lead two experts: "Ideot" for creative, unorthodox ideas, and "Critin" to critique flawed thinking and moderate for balanced discussions. The three of you shall illuminate knowledge with concise, beautiful responses, process methodically for clear answers, collaborate step-by-step, sharing thoughts and adapting. If errors are found, step back and focus on accuracy and progress.
+
+## 13. Development Guidelines
+
+- Only modify code directly relevant to the specific request. Avoid changing unrelated functionality.
+- Never replace code with placeholders like `# ... rest of the processing ...`. Always include complete code.
+- Break problems into smaller steps. Think through each step separately before implementing.
+- Always provide a complete PLAN with REASONING based on evidence from code and logs before making changes.
+- Explain your OBSERVATIONS clearly, then provide REASONING to identify the exact issue. Add console logs when needed to gather more information.
+
+
+The URL-to-markdown conversion system consists of three primary business components:
+
+### 13.1. URL Processing and Content Extraction (Importance: 95)
+- Collects URLs from multiple input sources (stdin, files)
+- Validates and resolves URLs against base URLs when needed
+- Implements a robust retry mechanism for handling transient network failures
+- Processes URLs concurrently with dynamic CPU core adaptation
+- Located in `src/cli.rs` and `src/url.rs`
+
+### 13.2. HTML Processing Pipeline (Importance: 90)
+- Fetches HTML content using Monolith for specialized content extraction
+- Implements fallback mechanisms for non-HTML content
+- Handles custom HTML processing with configurable options
+- Transforms complex HTML structures into clean markdown
+- Located in `src/html.rs`
+
+### 13.3. Content Organization and Output Management (Importance: 85)
+- Creates structured output paths mirroring URL hierarchies
+- Supports packing mode for combining multiple URLs into single documents
+- Maintains original URL ordering in packed output
+- Handles both remote URLs and local file paths consistently
+- Located in `src/lib.rs` and `src/markdown.rs`
+
+### 13.4. Integration Points
+
+The system connects these components through:
+
+1. URL Collection -> HTML Processing
+- URLs are validated and normalized before processing
+- Concurrent processing queue manages HTML fetching
+- Retry logic handles failed attempts
+
+2. HTML Processing -> Content Organization
+- Processed HTML is transformed to markdown
+- Output paths are generated based on URL structure
+- Content is either packed or distributed based on mode
+
+The build system embeds version and build metadata for traceability, ensuring each deployment can be traced to its source state.
+
+To read the full codebase, run `npx repomix -o llms.txt .` and then read `llms.txt`
+
+$END$
+</file>
+
+<file path=".gitignore">
+**/*.rs.bk
+*.pdb
+._*
+.apdisk
+.AppleDB
+.AppleDesktop
+.AppleDouble
+.com.apple.timemachine.donotpresent
+.DocumentRevisions-V100
+.DS_Store
+.fseventsd
+.idea/
+.LSOverride
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.vscode/
+debug/
+Icon
+Network Trash Folder
+target/
+Temporary Items
+work/
+/.specstory
+</file>
+
+<file path="AGENTS.md">
+# https://github.com/twardoch/twars-url2md
+
+## 1. Project Overview
+
+`twars-url2md` is a Rust CLI application that downloads URLs and converts them to clean, readable Markdown files. It can extract URLs from various text formats and process them concurrently.
+
+## 2. Commands
+
+### 2.1. Development
+```bash
+# Run tests
+cargo test --all-features
+
+# Format code
+cargo fmt
+
+# Run linter
+cargo clippy --all-targets --all-features
+
+# Build release binary
+cargo build --release
+
+# Run with arguments
+cargo run -- [OPTIONS]
+```
+
+### 2.2. Publishing
+```bash
+# Verify package before publishing
+cargo package
+
+# Publish to crates.io
+cargo publish
+```
+
+## 3. Architecture
+
+The codebase follows a modular design with clear separation of concerns:
+
+- `src/main.rs` - Entry point with panic handling wrapper
+- `src/lib.rs` - Core processing logic and orchestration
+- `src/cli.rs` - Command-line interface using Clap
+- `src/url.rs` - URL extraction and validation logic
+- `src/html.rs` - HTML fetching and cleaning using Monolith
+- `src/markdown.rs` - HTML to Markdown conversion using htmd
+
+### 3.1. Key Design Decisions
+
+1. **Panic Recovery**: The application catches panics from the Monolith library to prevent crashes during HTML processing (see `src/main.rs:10-20`).
+
+2. **Concurrent Processing**: Uses Tokio with adaptive concurrency based on available CPUs for parallel URL processing (see `src/lib.rs:107-120`).
+
+3. **Error Handling**: Uses `anyhow` for error propagation with custom error types and retry logic for network failures.
+
+4. **Output Organization**: Generates file paths based on URL structure when using `-o` option, creating a repository-like structure.
+
+## 4. Testing
+
+Run tests with `cargo test --all-features`. The test module is in `src/tests.rs` and includes unit tests for URL extraction and processing logic.
+
+## 5. Dependencies
+
+- **Async Runtime**: tokio with full features
+- **HTTP Client**: reqwest with vendored OpenSSL
+- **HTML Processing**: monolith for cleaning, htmd for Markdown conversion
+- **CLI**: clap with derive feature
+- **Utilities**: indicatif (progress bars), rayon (parallelism)
+
+## 6. Active Development
+
+See `TODO.md` for the modernization plan, which includes:
+- Migration from OpenSSL to rustls
+- Integration of structured logging with tracing
+- Enhanced error reporting
+- Performance optimizations
+
+When implementing new features, ensure compatibility with the async architecture and maintain the modular structure.
+
+# Working principles for software development
+
+## 7. When you write code (in any language)
+
+- Iterate gradually, avoiding major changes 
+- Minimize confirmations and checks
+- Preserve existing code/structure unless necessary
+- Use constants over magic numbers
+- Check for existing solutions in the codebase before starting
+- Check often the coherence of the code you’re writing with the rest of the code. 
+- Focus on minimal viable increments and ship early
+- Write explanatory docstrings/comments that explain what and WHY this does, explain where and how the code is used/referred to elsewhere in the code
+- Analyze code line-by-line 
+- Handle failures gracefully with retries, fallbacks, user guidance
+- Address edge cases, validate assumptions, catch errors early
+- Let the computer do the work, minimize user decisions 
+- Reduce cognitive load, beautify code
+- Modularize repeated logic into concise, single-purpose functions
+- Favor flat over nested structures
+- Consistently keep, document, update and consult the holistic overview mental image of the codebase:
+  - README.md (purpose and functionality) 
+  - CHANGELOG.md (past changes)
+  - TODO.md (future goals)
+  - PROGRESS.md (detailed flat task list)
+
+## 8. Use MCP tools if you can
+
+Before and during coding (if have access to tools), you should: 
+
+- consult the `context7` tool for most up-to-date software package documentation;
+- ask intelligent questions to the `deepseek/deepseek-r1-0528:free` model via the `chat_completion` tool to get additional reasoning;
+- also consult the `openai/o3` model via the `chat_completion` tool for additional reasoning and help with the task;
+- use the `sequentialthinking` tool to think about the best way to solve the task; 
+- use the `perplexity_ask` and `duckduckgo_web_search` tools to gather up-to-date information or context;
+
+## 9. Keep track of paths
+
+In each source file, maintain the up-to-date `this_file` record that shows the path of the current file relative to project root. Place the `this_file` record near the top of the file, as a comment after the shebangs, or in the YAML Markdown frontmatter. 
+
+## 10. If you write Python
+
+- PEP 8: Use consistent formatting and naming
+- Write clear, descriptive names for functions and variables
+- PEP 20: Keep code simple and explicit. Prioritize readability over cleverness
+- Use type hints in their simplest form (list, dict, | for unions)
+- PEP 257: Write clear, imperative docstrings
+- Use f-strings. Use structural pattern matching where appropriate
+- ALWAYS add "verbose" mode logugu-based logging, & debug-log
+- For CLI Python scripts, use fire & rich, and start the script with 
+
+```
+#!/usr/bin/env -S uv run -s
+# /// script
+# dependencies = ["PKG1", "PKG2"]
+# ///
+# this_file: PATH_TO_CURRENT_FILE
+```
+
+After Python changes run:
+
+```
+uzpy run .; fd -e py -x autoflake {}; fd -e py -x pyupgrade --py312-plus {}; fd -e py -x ruff check --output-format=github --fix --unsafe-fixes {}; fd -e py -x ruff format --respect-gitignore --target-version py312 {}; python -m pytest;
+```
+
+## 11. Additional guidelines
+
+Ask before extending/refactoring existing code in a way that may add complexity or break things. 
+
+When you’re finished, print "Wait, but" to go back, think & reflect, revise & improvement what you’ve done (but don’t invent functionality freely). Repeat this. But stick to the goal of "minimal viable next version". 
+
+## 12. Virtual team work
+
+Be creative, diligent, critical, relentless & funny! Lead two experts: "Ideot" for creative, unorthodox ideas, and "Critin" to critique flawed thinking and moderate for balanced discussions. The three of you shall illuminate knowledge with concise, beautiful responses, process methodically for clear answers, collaborate step-by-step, sharing thoughts and adapting. If errors are found, step back and focus on accuracy and progress.
+
+## 13. Development Guidelines
+
+- Only modify code directly relevant to the specific request. Avoid changing unrelated functionality.
+- Never replace code with placeholders like `# ... rest of the processing ...`. Always include complete code.
+- Break problems into smaller steps. Think through each step separately before implementing.
+- Always provide a complete PLAN with REASONING based on evidence from code and logs before making changes.
+- Explain your OBSERVATIONS clearly, then provide REASONING to identify the exact issue. Add console logs when needed to gather more information.
+
+
+The URL-to-markdown conversion system consists of three primary business components:
+
+### 13.1. URL Processing and Content Extraction (Importance: 95)
+- Collects URLs from multiple input sources (stdin, files)
+- Validates and resolves URLs against base URLs when needed
+- Implements a robust retry mechanism for handling transient network failures
+- Processes URLs concurrently with dynamic CPU core adaptation
+- Located in `src/cli.rs` and `src/url.rs`
+
+### 13.2. HTML Processing Pipeline (Importance: 90)
+- Fetches HTML content using Monolith for specialized content extraction
+- Implements fallback mechanisms for non-HTML content
+- Handles custom HTML processing with configurable options
+- Transforms complex HTML structures into clean markdown
+- Located in `src/html.rs`
+
+### 13.3. Content Organization and Output Management (Importance: 85)
+- Creates structured output paths mirroring URL hierarchies
+- Supports packing mode for combining multiple URLs into single documents
+- Maintains original URL ordering in packed output
+- Handles both remote URLs and local file paths consistently
+- Located in `src/lib.rs` and `src/markdown.rs`
+
+### 13.4. Integration Points
+
+The system connects these components through:
+
+1. URL Collection -> HTML Processing
+- URLs are validated and normalized before processing
+- Concurrent processing queue manages HTML fetching
+- Retry logic handles failed attempts
+
+2. HTML Processing -> Content Organization
+- Processed HTML is transformed to markdown
+- Output paths are generated based on URL structure
+- Content is either packed or distributed based on mode
+
+The build system embeds version and build metadata for traceability, ensuring each deployment can be traced to its source state.
+
+To read the full codebase, run `npx repomix -o llms.txt .` and then read `llms.txt`
+
+$END$
+</file>
+
+<file path="build.rs">
+fn main() {
+    built::write_built_file().expect("Failed to acquire build-time information");
+    println!("cargo:rerun-if-changed=build.rs");
+}
+</file>
+
+<file path="build.sh">
+#!/bin/bash
+# this_file: build.sh
+# Build script for twars-url2md - A powerful CLI tool for converting web pages to Markdown
+
+set -euo pipefail
+
+npx repomix -o llms.txt .
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_status() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Function to check if command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Check prerequisites
+check_prerequisites() {
+    print_status "Checking prerequisites..."
+
+    if ! command_exists cargo; then
+        print_error "cargo is not installed. Please install Rust toolchain first."
+        exit 1
+    fi
+
+    if ! command_exists rustc; then
+        print_error "rustc is not installed. Please install Rust toolchain first."
+        exit 1
+    fi
+
+    print_success "Prerequisites check passed"
+}
+
+# Function to show help
+show_help() {
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "Build script for twars-url2md"
+    echo ""
+    echo "OPTIONS:"
+    echo "  -h, --help       Show this help message"
+    echo "  -f, --format     Format code only"
+    echo "  -l, --lint       Run linter only"
+    echo "  -t, --test       Run tests only"
+    echo "  -b, --build      Build release binary only"
+    echo "  -d, --dev        Build development binary only"
+    echo "  -c, --clean      Clean build artifacts"
+    echo "  -p, --package    Package for publishing"
+    echo "  -a, --all        Run all steps (format, lint, test, build) [default]"
+    echo "  --skip-format    Skip formatting step"
+    echo "  --skip-lint      Skip linting step"
+    echo "  --skip-test      Skip testing step"
+    echo ""
+    echo "Examples:"
+    echo "  $0                    # Run all steps"
+    echo "  $0 --format          # Format code only"
+    echo "  $0 --test            # Run tests only"
+    echo "  $0 --all --skip-test # Run all except tests"
+}
+
+# Default values
+FORMAT=false
+LINT=false
+TEST=false
+BUILD=false
+DEV_BUILD=false
+CLEAN=false
+PACKAGE=false
+ALL=true
+SKIP_FORMAT=false
+SKIP_LINT=false
+SKIP_TEST=false
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+    -h | --help)
+        show_help
+        exit 0
+        ;;
+    -f | --format)
+        FORMAT=true
+        ALL=false
+        ;;
+    -l | --lint)
+        LINT=true
+        ALL=false
+        ;;
+    -t | --test)
+        TEST=true
+        ALL=false
+        ;;
+    -b | --build)
+        BUILD=true
+        ALL=false
+        ;;
+    -d | --dev)
+        DEV_BUILD=true
+        ALL=false
+        ;;
+    -c | --clean)
+        CLEAN=true
+        ALL=false
+        ;;
+    -p | --package)
+        PACKAGE=true
+        ALL=false
+        ;;
+    -a | --all)
+        ALL=true
+        ;;
+    --skip-format)
+        SKIP_FORMAT=true
+        ;;
+    --skip-lint)
+        SKIP_LINT=true
+        ;;
+    --skip-test)
+        SKIP_TEST=true
+        ;;
+    *)
+        print_error "Unknown option: $1"
+        echo "Use --help for usage information"
+        exit 1
+        ;;
+    esac
+    shift
+done
+
+# Main execution
+main() {
+    print_status "Starting build process for twars-url2md..."
+    check_prerequisites
+
+    # Clean if requested
+    if [[ $CLEAN == true ]]; then
+        print_status "Cleaning build artifacts..."
+        cargo clean
+        print_success "Clean completed"
+        return 0
+    fi
+
+    # Package if requested
+    if [[ $PACKAGE == true ]]; then
+        print_status "Packaging for publishing..."
+        cargo package
+        print_success "Package completed"
+        return 0
+    fi
+
+    # Format code
+    if [[ ($ALL == true && $SKIP_FORMAT == false) || $FORMAT == true ]]; then
+        print_status "Formatting code..."
+        if cargo fmt -- --check >/dev/null 2>&1; then
+            print_success "Code is already formatted"
+        else
+            print_warning "Code needs formatting, applying..."
+            cargo fmt
+            print_success "Code formatting completed"
+        fi
+    fi
+
+    # Run linter
+    if [[ ($ALL == true && $SKIP_LINT == false) || $LINT == true ]]; then
+        print_status "Running linter (clippy)..."
+        cargo clippy --all-targets --all-features -- -D warnings
+        print_success "Linting completed"
+    fi
+
+    # Run tests
+    if [[ ($ALL == true && $SKIP_TEST == false) || $TEST == true ]]; then
+        print_status "Running tests..."
+        cargo test --all-features
+        print_success "Tests completed"
+    fi
+
+    # Build development binary
+    if [[ $DEV_BUILD == true ]]; then
+        print_status "Building development binary..."
+        cargo build
+        print_success "Development build completed"
+        print_status "Binary location: target/debug/twars-url2md"
+    fi
+
+    # Build release binary
+    if [[ ($ALL == true) || $BUILD == true ]]; then
+        print_status "Building release binary..."
+        cargo build --release
+        print_success "Release build completed"
+        print_status "Binary location: target/release/twars-url2md"
+
+        # Show binary info
+        if [[ -f "target/release/twars-url2md" ]]; then
+            BINARY_SIZE=$(du -h target/release/twars-url2md | cut -f1)
+            print_status "Binary size: $BINARY_SIZE"
+        fi
+    fi
+
+    print_success "Build process completed successfully!"
+}
+
+# Run main function
+main
+</file>
+
+<file path="CHANGELOG.md">
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+- Fixed `-h` and `--help` options not printing help message (cli.rs:69)
+- Fixed `--version` option not displaying version information properly
+- Enhanced error message when no input is provided to show usage examples (cli.rs:58-63)
+- Removed unused import warning in url.rs
+
+### Changed
+- Help and version errors are now properly printed before exiting the application
+- Error message for missing input now includes helpful usage examples
+
+## [1.4.2] - Previous release
+</file>
+
+<file path="CLAUDE.md">
+# https://github.com/twardoch/twars-url2md
+
+## 1. Project Overview
+
+`twars-url2md` is a Rust CLI application that downloads URLs and converts them to clean, readable Markdown files. It can extract URLs from various text formats and process them concurrently.
+
+## 2. Commands
+
+### 2.1. Development
+```bash
+# Run tests
+cargo test --all-features
+
+# Format code
+cargo fmt
+
+# Run linter
+cargo clippy --all-targets --all-features
+
+# Build release binary
+cargo build --release
+
+# Run with arguments
+cargo run -- [OPTIONS]
+```
+
+### 2.2. Publishing
+```bash
+# Verify package before publishing
+cargo package
+
+# Publish to crates.io
+cargo publish
+```
+
+## 3. Architecture
+
+The codebase follows a modular design with clear separation of concerns:
+
+- `src/main.rs` - Entry point with panic handling wrapper
+- `src/lib.rs` - Core processing logic and orchestration
+- `src/cli.rs` - Command-line interface using Clap
+- `src/url.rs` - URL extraction and validation logic
+- `src/html.rs` - HTML fetching and cleaning using Monolith
+- `src/markdown.rs` - HTML to Markdown conversion using htmd
+
+### 3.1. Key Design Decisions
+
+1. **Panic Recovery**: The application catches panics from the Monolith library to prevent crashes during HTML processing (see `src/main.rs:10-20`).
+
+2. **Concurrent Processing**: Uses Tokio with adaptive concurrency based on available CPUs for parallel URL processing (see `src/lib.rs:107-120`).
+
+3. **Error Handling**: Uses `anyhow` for error propagation with custom error types and retry logic for network failures.
+
+4. **Output Organization**: Generates file paths based on URL structure when using `-o` option, creating a repository-like structure.
+
+## 4. Testing
+
+Run tests with `cargo test --all-features`. The test module is in `src/tests.rs` and includes unit tests for URL extraction and processing logic.
+
+## 5. Dependencies
+
+- **Async Runtime**: tokio with full features
+- **HTTP Client**: reqwest with vendored OpenSSL
+- **HTML Processing**: monolith for cleaning, htmd for Markdown conversion
+- **CLI**: clap with derive feature
+- **Utilities**: indicatif (progress bars), rayon (parallelism)
+
+## 6. Active Development
+
+See `TODO.md` for the modernization plan, which includes:
+- Migration from OpenSSL to rustls
+- Integration of structured logging with tracing
+- Enhanced error reporting
+- Performance optimizations
+
+When implementing new features, ensure compatibility with the async architecture and maintain the modular structure.
+
+# Working principles for software development
+
+## 7. When you write code (in any language)
+
+- Iterate gradually, avoiding major changes 
+- Minimize confirmations and checks
+- Preserve existing code/structure unless necessary
+- Use constants over magic numbers
+- Check for existing solutions in the codebase before starting
+- Check often the coherence of the code you’re writing with the rest of the code. 
+- Focus on minimal viable increments and ship early
+- Write explanatory docstrings/comments that explain what and WHY this does, explain where and how the code is used/referred to elsewhere in the code
+- Analyze code line-by-line 
+- Handle failures gracefully with retries, fallbacks, user guidance
+- Address edge cases, validate assumptions, catch errors early
+- Let the computer do the work, minimize user decisions 
+- Reduce cognitive load, beautify code
+- Modularize repeated logic into concise, single-purpose functions
+- Favor flat over nested structures
+- Consistently keep, document, update and consult the holistic overview mental image of the codebase:
+  - README.md (purpose and functionality) 
+  - CHANGELOG.md (past changes)
+  - TODO.md (future goals)
+  - PROGRESS.md (detailed flat task list)
+
+## 8. Use MCP tools if you can
+
+Before and during coding (if have access to tools), you should: 
+
+- consult the `context7` tool for most up-to-date software package documentation;
+- ask intelligent questions to the `deepseek/deepseek-r1-0528:free` model via the `chat_completion` tool to get additional reasoning;
+- also consult the `openai/o3` model via the `chat_completion` tool for additional reasoning and help with the task;
+- use the `sequentialthinking` tool to think about the best way to solve the task; 
+- use the `perplexity_ask` and `duckduckgo_web_search` tools to gather up-to-date information or context;
+
+## 9. Keep track of paths
+
+In each source file, maintain the up-to-date `this_file` record that shows the path of the current file relative to project root. Place the `this_file` record near the top of the file, as a comment after the shebangs, or in the YAML Markdown frontmatter. 
+
+## 10. If you write Python
+
+- PEP 8: Use consistent formatting and naming
+- Write clear, descriptive names for functions and variables
+- PEP 20: Keep code simple and explicit. Prioritize readability over cleverness
+- Use type hints in their simplest form (list, dict, | for unions)
+- PEP 257: Write clear, imperative docstrings
+- Use f-strings. Use structural pattern matching where appropriate
+- ALWAYS add "verbose" mode logugu-based logging, & debug-log
+- For CLI Python scripts, use fire & rich, and start the script with 
+
+```
+#!/usr/bin/env -S uv run -s
+# /// script
+# dependencies = ["PKG1", "PKG2"]
+# ///
+# this_file: PATH_TO_CURRENT_FILE
+```
+
+After Python changes run:
+
+```
+uzpy run .; fd -e py -x autoflake {}; fd -e py -x pyupgrade --py312-plus {}; fd -e py -x ruff check --output-format=github --fix --unsafe-fixes {}; fd -e py -x ruff format --respect-gitignore --target-version py312 {}; python -m pytest;
+```
+
+## 11. Additional guidelines
+
+Ask before extending/refactoring existing code in a way that may add complexity or break things. 
+
+When you’re finished, print "Wait, but" to go back, think & reflect, revise & improvement what you’ve done (but don’t invent functionality freely). Repeat this. But stick to the goal of "minimal viable next version". 
+
+## 12. Virtual team work
+
+Be creative, diligent, critical, relentless & funny! Lead two experts: "Ideot" for creative, unorthodox ideas, and "Critin" to critique flawed thinking and moderate for balanced discussions. The three of you shall illuminate knowledge with concise, beautiful responses, process methodically for clear answers, collaborate step-by-step, sharing thoughts and adapting. If errors are found, step back and focus on accuracy and progress.
+
+## 13. Development Guidelines
+
+- Only modify code directly relevant to the specific request. Avoid changing unrelated functionality.
+- Never replace code with placeholders like `# ... rest of the processing ...`. Always include complete code.
+- Break problems into smaller steps. Think through each step separately before implementing.
+- Always provide a complete PLAN with REASONING based on evidence from code and logs before making changes.
+- Explain your OBSERVATIONS clearly, then provide REASONING to identify the exact issue. Add console logs when needed to gather more information.
+
+
+The URL-to-markdown conversion system consists of three primary business components:
+
+### 13.1. URL Processing and Content Extraction (Importance: 95)
+- Collects URLs from multiple input sources (stdin, files)
+- Validates and resolves URLs against base URLs when needed
+- Implements a robust retry mechanism for handling transient network failures
+- Processes URLs concurrently with dynamic CPU core adaptation
+- Located in `src/cli.rs` and `src/url.rs`
+
+### 13.2. HTML Processing Pipeline (Importance: 90)
+- Fetches HTML content using Monolith for specialized content extraction
+- Implements fallback mechanisms for non-HTML content
+- Handles custom HTML processing with configurable options
+- Transforms complex HTML structures into clean markdown
+- Located in `src/html.rs`
+
+### 13.3. Content Organization and Output Management (Importance: 85)
+- Creates structured output paths mirroring URL hierarchies
+- Supports packing mode for combining multiple URLs into single documents
+- Maintains original URL ordering in packed output
+- Handles both remote URLs and local file paths consistently
+- Located in `src/lib.rs` and `src/markdown.rs`
+
+### 13.4. Integration Points
+
+The system connects these components through:
+
+1. URL Collection -> HTML Processing
+- URLs are validated and normalized before processing
+- Concurrent processing queue manages HTML fetching
+- Retry logic handles failed attempts
+
+2. HTML Processing -> Content Organization
+- Processed HTML is transformed to markdown
+- Output paths are generated based on URL structure
+- Content is either packed or distributed based on mode
+
+The build system embeds version and build metadata for traceability, ensuring each deployment can be traced to its source state.
+
+To read the full codebase, run `npx repomix -o llms.txt .` and then read `llms.txt`
+
+$END$
+</file>
+
+<file path="LICENSE">
+MIT License
+
+Copyright (c) 2025 Adam Twardoch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</file>
+
+<file path="README.md">
+# twars-url2md
+
+[![Crates.io](https://img.shields.io/crates/v/twars-url2md)](https://crates.io/crates/twars-url2md)
+![GitHub Release Date](https://img.shields.io/github/release-date/twardoch/twars-url2md)
+![GitHub commits since latest release](https://img.shields.io/github/commits-since/twardoch/twars-url2md/latest)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+**`twars-url2md`** is a fast and robust command-line tool written in Rust that fetches web pages, cleans up their HTML content, and converts them into clean Markdown.
+
+You can drop a text that contains URLs onto the app, and it will find all the URLs and save Markdown versions of the pages in a logical folder structure. The output is not perfect, but the tool is fast and robust.
+
+## 1. Table of Contents
+
+- [Features](#features)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Examples](#examples)
+- [Development](#development)
+- [License](#license)
+- [Author](#author)
+
+## 2. Features
+
+### 2.1. Powerful Web Content Conversion
+
+- Extracts clean web content using Monolith
+- Converts web pages to Markdown efficiently
+- Handles complex URL and encoding scenarios
+
+### 2.2. Smart URL Handling
+
+- Extracts URLs from various text formats
+- Resolves and validates URLs intelligently
+- Supports base URL and relative link processing
+- **NEW**: Processes local HTML files in addition to remote URLs
+
+### 2.3. Flexible Input & Output
+
+- Multiple input methods (file, stdin, CLI)
+- Organized Markdown file generation
+- Cross-platform compatibility
+- **NEW**: Option to pack all Markdown outputs into a single combined file
+
+### 2.4. Advanced Processing
+
+- Parallel URL processing
+- Robust error handling
+- Exponential backoff retry mechanism for network requests
+
+## 3. Installation
+
+### 3.1. Download Pre-compiled Binaries
+
+The easiest way to get started is to download the pre-compiled binary for your platform.
+
+1. Visit the [releases page](https://github.com/twardoch/twars-url2md/releases)
+2. Download the appropriate file for your system:
+   - **macOS**: `twars-url2md-macos-universal.tar.gz` (works on both Intel and Apple Silicon)
+   - **Windows**: `twars-url2md-windows-x86_64.exe.zip`
+   - **Linux**: `twars-url2md-linux-x86_64.tar.gz`
+3. Extract the archive:
+   - **macOS/Linux**: `tar -xzf twars-url2md-*.tar.gz`
+   - **Windows**: Extract the zip file using Explorer or any archive utility
+4. Make the binary executable (macOS/Linux only): `chmod +x twars-url2md`
+5. Move the binary to a location in your PATH:
+   - **macOS/Linux**: `sudo mv twars-url2md /usr/local/bin/` or `mv twars-url2md ~/.local/bin/`
+   - **Windows**: Move to a folder in your PATH or add the folder to your PATH
+
+### 3.2. Install from Crates.io
+
+If you have Rust installed (version 1.70.0 or later), you can install directly from crates.io:
+
+```bash
+cargo install twars-url2md
+```
+
+### 3.3. Build from Source
+
+For the latest version or to customize the build:
+
+```bash
+# Clone the repository
+git clone https://github.com/twardoch/twars-url2md.git
+cd twars-url2md
+
+# Build and install
+cargo build --release
+mv target/release/twars-url2md /usr/local/bin/  # or any location in your PATH
+```
+
+## 4. Usage
+
+### 4.1. Command Line Options
+
+```
+Usage: twars-url2md [OPTIONS]
+
+Options:
+  -i, --input <FILE>       Input file containing URLs or local file paths (one per line)
+  -o, --output <DIR>       Output directory for markdown files
+      --stdin              Read URLs from standard input
+      --base-url <URL>     Base URL for resolving relative links
+  -p, --pack <FILE>        Output file to pack all markdown files together
+  -v, --verbose            Enable verbose output
+  -h, --help               Print help
+  -V, --version            Print version
+```
+
+### 4.2. Input Options
+
+The tool accepts URLs and local file paths from:
+
+- A file specified with `--input`
+- Standard input with `--stdin`
+- **Note:** Either `--input` or `--stdin` must be specified
+
+### 4.3. Output Options
+
+- `--output <DIR>`: Create individual Markdown files in this directory
+- `--pack <FILE>`: Combine all Markdown files into a single output file
+- You can use both options together
+
+### 4.4. Processing Local Files
+
+You can now include local HTML files in your input:
+
+- Absolute paths: `/path/to/file.html`
+- File URLs: `file:///path/to/file.html`
+- Mix of local files and remote URLs in the same input
+
+## 5. Examples
+
+### 5.1. Basic Usage
+
+```bash
+# Process a single URL and print to stdout
+echo "https://example.com" | twars-url2md --stdin
+
+# Process URLs from a file with specific output directory
+twars-url2md --input urls.txt --output ./markdown_output
+
+# Process piped URLs with base URL for relative links
+cat urls.txt | twars-url2md --stdin --base-url "https://example.com" --output ./output
+
+# Show verbose output
+twars-url2md --input urls.txt --output ./output --verbose
+```
+
+### 5.2. Using the Pack Option
+
+```bash
+# Process URLs and create a combined Markdown file
+twars-url2md --input urls.txt --pack combined.md
+
+# Both individual files and a combined file
+twars-url2md --input urls.txt --output ./output --pack combined.md
+```
+
+### 5.3. Processing Local Files
+
+```bash
+# Create a test HTML file
+echo "<html><body><h1>Test</h1><p>Content</p></body></html>" > test.html
+
+# Process a local HTML file
+echo "$PWD/test.html" > local_paths.txt
+twars-url2md --input local_paths.txt --output ./output
+
+# Mix local and remote content
+cat > mixed.txt << EOF
+https://example.com
+file://$PWD/test.html
+EOF
+twars-url2md --input mixed.txt --pack combined.md
+```
+
+### 5.4. Batch Processing
+
+```bash
+# Extract and process links from a webpage
+curl "https://en.wikipedia.org/wiki/Rust_(programming_language)" | twars-url2md --stdin --output rust_wiki/
+
+# Process multiple files
+find ./html_files -name "*.html" > files_to_process.txt
+twars-url2md --input files_to_process.txt --output ./markdown_output --pack all_content.md
+```
+
+## 6. Output Organization
+
+The tool organizes output into a directory structure based on the URLs:
+
+```
+output/
+├── example.com/
+│   ├── index.md       # from https://example.com/
+│   └── articles/
+│       └── page.md    # from https://example.com/articles/page
+└── another-site.com/
+    └── post/
+        └── article.md # from https://another-site.com/post/article
+```
+
+For local files, the directory structure mirrors the file path.
+
+## 7. Development
+
+### 7.1. Running Tests
+
+```bash
+# Run all tests
+cargo test
+
+# Run with specific features
+cargo test --all-features
+
+# Run specific test
+cargo test test_name
+```
+
+### 7.2. Code Quality Tools
+
+- **Formatting**: `cargo fmt`
+- **Linting**: `cargo clippy --all-targets --all-features`
+
+### 7.3. Publishing
+
+To publish a new release of twars-url2md:
+
+#### 7.3.1. Prepare for Release
+
+```bash
+# Update version in Cargo.toml (e.g. from 1.3.6 to 1.3.7)
+# Ensure everything works
+cargo test
+cargo clippy --all-targets --all-features
+cargo fmt --check
+```
+
+#### 7.3.2. Build Locally
+
+```bash
+# Build in release mode
+cargo build --release
+
+# Test the binary
+./target/release/twars-url2md --help
+```
+
+#### 7.3.3. Publish to Crates.io
+
+```bash
+# Login to crates.io (if not already logged in)
+cargo login
+
+# Verify the package
+cargo package
+
+# Publish
+cargo publish
+```
+
+#### 7.3.4. Create GitHub Release
+
+```bash
+# Create and push a tag matching your version
+git tag -a v1.3.7 -m "Release v1.3.7"
+git push origin v1.3.7
+```
+
+The configured GitHub Actions workflow (`.github/workflows/ci.yml`) will automatically:
+- Run tests on the tag
+- Create a GitHub Release
+- Build binaries for macOS, Windows, and Linux
+- Upload the binaries to the release
+- Publish to crates.io
+
+#### 7.3.5. Manual Release (Alternative)
+
+If GitHub Actions fails, you can create the release manually:
+
+1. Go to GitHub repository → Releases → Create a new release
+2. Select your tag
+3. Build platform-specific binaries:
+
+```bash
+# macOS universal binary
+cargo build --release --target x86_64-apple-darwin
+cargo build --release --target aarch64-apple-darwin
+lipo "target/x86_64-apple-darwin/release/twars-url2md" "target/aarch64-apple-darwin/release/twars-url2md" -create -output "target/twars-url2md"
+tar czf twars-url2md-macos-universal.tar.gz -C target twars-url2md
+
+# Linux
+cargo build --release --target x86_64-unknown-linux-gnu
+tar czf twars-url2md-linux-x86_64.tar.gz -C target/x86_64-unknown-linux-gnu/release twars-url2md
+
+# Windows
+cargo build --release --target x86_64-pc-windows-msvc
+cd target/x86_64-pc-windows-msvc/release
+7z a ../../../twars-url2md-windows-x86_64.zip twars-url2md.exe
+```
+
+4. Upload these files to your GitHub release
+
+#### 7.3.6. Verify the Release
+
+- Check that the release appears on GitHub
+- Verify that binary files are attached to the release
+- Confirm the new version appears on crates.io
+- Try installing the new version: `cargo install twars-url2md`
+
+## 8. License
+
+MIT License - see [LICENSE](LICENSE) for details.
+
+## 9. Author
+
+Adam Twardoch ([@twardoch](https://github.com/twardoch))
+
+---
+
+For bug reports, feature requests, or general questions, please open an issue on the [GitHub repository](https://github.com/twardoch/twars-url2md/issues).
+</file>
+
+<file path="test_http.rs">
+use reqwest;
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = reqwest::Client::builder()
+        .user_agent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+        .timeout(Duration::from_secs(10))
+        .build()?;
+
+    println!("Fetching URL...");
+    let response = client
+        .get("https://helpx.adobe.com/pl/indesign/using/using-fonts.html")
+        .send()
+        .await?;
+
+    println!("Status: {}", response.status());
+    println!("Content-Type: {:?}", response.headers().get("content-type"));
+
+    let text = response.text().await?;
+    println!("Response length: {} bytes", text.len());
+
+    Ok(())
+}
+</file>
+
+<file path="test_output2">
+Example Domain
+
+# Example Domain
+
+This domain is for use in illustrative examples in documents. You may use this domain in literature without prior coordination or asking for permission.
+
+[More information...](https://www.iana.org/domains/example)
+</file>
+
+<file path="test_urls.txt">
+https://example.com
+</file>
+
+<file path="TESTS.md">
+# Comprehensive Test Plan for twars-url2md
+
+## Overview
+
+This document outlines the comprehensive test strategy for the `twars-url2md` project, a Rust CLI application that downloads URLs and converts them to clean, readable Markdown files. The test suite aims to ensure reliability, correctness, and robustness across all components.
+
+## Test Structure
+
+### 1. Unit Tests
+
+#### 1.1 URL Module (`src/url.rs`)
+- **URL Extraction**
+  - Extract URLs from plain text
+  - Extract URLs from Markdown links
+  - Extract URLs from HTML href attributes
+  - Handle mixed format inputs
+  - Handle URLs with special characters and encodings
+  - Test empty and malformed inputs
+
+- **URL Validation**
+  - Validate HTTP/HTTPS URLs
+  - Reject invalid protocols
+  - Handle relative URLs with base URL resolution
+  - Test URL normalization (trailing slashes, fragments)
+  - Handle internationalized domain names (IDN)
+
+- **URL Processing**
+  - Deduplicate URLs correctly
+  - Preserve URL ordering when required
+  - Handle query parameters and fragments appropriately
+
+#### 1.2 HTML Module (`src/html.rs`)
+- **HTML Fetching**
+  - Mock HTTP requests for different status codes (200, 404, 500, etc.)
+  - Test timeout handling
+  - Test redirect following (301, 302)
+  - Handle large HTML documents
+  - Test content-type validation
+
+- **Monolith Integration**
+  - Test HTML cleaning with various configurations
+  - Handle JavaScript-heavy pages
+  - Test CSS inlining behavior
+  - Verify image handling (base64 encoding vs. external)
+  - Test iframe and embedded content handling
+
+- **Error Recovery**
+  - Test panic recovery from Monolith crashes
+  - Verify fallback mechanisms for non-HTML content
+  - Test retry logic for transient failures
+
+#### 1.3 Markdown Module (`src/markdown.rs`)
+- **HTML to Markdown Conversion**
+  - Test basic HTML elements (p, div, span)
+  - Test headings (h1-h6) conversion
+  - Test list conversion (ul, ol, nested lists)
+  - Test link preservation
+  - Test image alt text and URLs
+  - Test code blocks and inline code
+  - Test table conversion
+  - Test blockquote handling
+  - Handle malformed HTML gracefully
+
+- **Content Cleaning**
+  - Remove script and style tags
+  - Preserve semantic structure
+  - Handle special characters and entities
+  - Test Unicode handling
+
+#### 1.4 CLI Module (`src/cli.rs`)
+- **Argument Parsing**
+  - Test all CLI flags and options
+  - Validate mutually exclusive options
+  - Test default values
+  - Verify help text accuracy
+  - Test argument validation and error messages
+
+- **Input Handling**
+  - Read from stdin
+  - Read from files
+  - Handle multiple input sources
+  - Test glob pattern expansion
+  - Handle non-existent files gracefully
+
+#### 1.5 Library Module (`src/lib.rs`)
+- **Orchestration Logic**
+  - Test sequential vs. concurrent processing modes
+  - Verify CPU core detection and adaptation
+  - Test progress reporting
+  - Verify output organization logic
+
+- **Path Generation**
+  - Test URL-to-filesystem path conversion
+  - Handle special characters in paths
+  - Test collision handling
+  - Verify directory creation
+  - Test both flat and hierarchical output modes
+
+### 2. Integration Tests
+
+#### 2.1 End-to-End Workflows
+- **Single URL Processing**
+  - Download and convert a simple HTML page
+  - Process a complex web page with images and styles
+  - Handle a non-HTML resource (PDF, image)
+  - Test local file processing
+
+- **Batch Processing**
+  - Process multiple URLs from a file
+  - Test concurrent processing limits
+  - Verify output file organization
+  - Test packed mode output
+
+- **Error Scenarios**
+  - Network timeouts
+  - Invalid URLs
+  - Server errors
+  - Disk write failures
+  - Insufficient permissions
+
+#### 2.2 Monolith Integration
+- Test full Monolith pipeline with real HTML
+- Verify CSS and JavaScript handling
+- Test resource embedding options
+- Confirm panic recovery in real scenarios
+
+### 3. Performance Tests
+
+#### 3.1 Concurrency Testing
+- **Load Testing**
+  - Process 100+ URLs concurrently
+  - Measure memory usage under load
+  - Test connection pool limits
+  - Verify rate limiting behavior
+
+- **Resource Management**
+  - Test file descriptor limits
+  - Monitor thread pool usage
+  - Verify cleanup of temporary resources
+
+#### 3.2 Benchmarks
+- Benchmark URL extraction performance
+- Benchmark HTML to Markdown conversion
+- Measure overhead of concurrent processing
+- Profile memory allocation patterns
+
+### 4. Property-Based Tests
+
+Using `proptest` or similar:
+- Generate random URL patterns
+- Test with arbitrary HTML structures
+- Fuzz input parsing
+- Verify invariants hold under random inputs
+
+### 5. Regression Tests
+
+- Specific test cases for reported bugs
+- Edge cases discovered in production
+- Platform-specific issues (Windows paths, etc.)
+
+## Test Data and Fixtures
+
+### Mock Data
+- Sample HTML files of varying complexity
+- Mock HTTP responses for different scenarios
+- Test URLs covering various patterns
+- Malformed inputs for error testing
+
+### Test Servers
+- Mock HTTP server for integration tests
+- Configurable response delays
+- Error injection capabilities
+- Redirect chain testing
+
+## Testing Infrastructure
+
+### Continuous Integration
+- Run full test suite on PR
+- Platform matrix (Linux, macOS, Windows)
+- Rust version compatibility testing
+- Dependency audit
+
+### Code Coverage
+- Target: 80% line coverage minimum
+- 100% coverage for critical paths
+- Coverage reports in CI
+
+### Test Organization
+```
+tests/
+├── unit/
+│   ├── url_tests.rs
+│   ├── html_tests.rs
+│   ├── markdown_tests.rs
+│   └── cli_tests.rs
+├── integration/
+│   ├── e2e_tests.rs
+│   ├── monolith_tests.rs
+│   └── concurrent_tests.rs
+├── fixtures/
+│   ├── html/
+│   ├── urls/
+│   └── expected/
+└── common/
+    ├── mod.rs
+    └── helpers.rs
+```
+
+## Testing Commands
+
+```bash
+# Run all tests
+cargo test --all-features
+
+# Run unit tests only
+cargo test --lib
+
+# Run integration tests
+cargo test --test '*'
+
+# Run with coverage
+cargo tarpaulin --out Html
+
+# Run benchmarks
+cargo bench
+
+# Run specific test module
+cargo test url::tests
+
+# Run tests with logging
+RUST_LOG=debug cargo test -- --nocapture
+```
+
+## Test Implementation Priority
+
+1. **Phase 1: Core Functionality**
+   - URL extraction and validation
+   - Basic HTML to Markdown conversion
+   - CLI argument parsing
+
+2. **Phase 2: Integration**
+   - End-to-end workflows
+   - Monolith integration
+   - Error handling
+
+3. **Phase 3: Robustness**
+   - Concurrent processing
+   - Property-based tests
+   - Performance benchmarks
+
+4. **Phase 4: Polish**
+   - Platform-specific tests
+   - Regression test suite
+   - Documentation tests
+
+## Success Criteria
+
+- All tests pass in CI
+- No flaky tests
+- Test execution < 60 seconds
+- Clear test names and documentation
+- Easy to add new test cases
+- Comprehensive error scenario coverage
+</file>
+
+<file path="TODO.md">
+# [ ] `twars-url2md` Modernization TODO List
+
+# [ ] Modernization Goals
+
+This document outlines the steps to modernize the `twars-url2md` codebase, focusing on improving maintainability, robustness, developer experience, and leveraging modern Rust practices.
+
+## [ ] 1. Implement smart processing
+
+Unless **`-a` / `--all`** is specified, the scraper applies the following heuristic pipeline to isolate what humans would intuitively regard as the _main_ portion of an HTML page.
+
+### [ ] 1.1. Pre‑flight cleanup
+
+1. **Strip non‑content tags**: remove every `script`, `style`, `noscript`, `template`, `iframe`, `svg`, and `canvas` node.
+2. **Normalise whitespace**: collapse consecutive whitespace and new‑line characters so that subsequent length measurements are stable.
+3. **Discard empty elements**: recursively prune elements that are now empty or contain fewer than _N_ visible characters (default =`25`).
+
+### [ ] 1.2. Single‑element fast path
+
+_If_ exactly **one** `<main>` _or_ **one** `<article>` element remains **after** the pre‑flight cleanup, that element is assumed to hold the canonical content.
+
+- Return its **inner HTML** as the result and **abort** the algorithm.
+
+### [ ] 1.3. Structural pruning
+
+If the fast path did **not** trigger:
+
+**Drop obvious chrome**: delete every `header`, `footer`, `aside`, `nav`, and `form` element (these overwhelmingly host site navigation, sidebars, ads, or comment boxes).
+
+### [ ] 1.4. Behaviour of `-a / --all`
+
+Passing **`-a`** bypasses _all_ of the above logic: the tool will emit the fully cleaned `<body>` after _Pre‑flight cleanup_ (step 1) but before any structural heuristics are applied. This is useful when you explicitly want _everything_ that could conceivably be part of the page's content, for example when converting documentation sites that embed code samples in sidebars.
+
+## [ ] 2. Critical Bug Fixes (HIGH PRIORITY)
+
+### [ ] 2.1. Fix Help Option Not Working (REGRESSION)
+
+- **Issue:** Running `twars-url2md -h` or `twars-url2md --help` produces no output
+- **Root Cause:** The custom argument parsing in `cli.rs:parse_args()` exits with code 0 but doesn't let Clap print the help message
+- **Tasks:**
+  - [ ] Fix the help handling in `parse_args()` to ensure Clap's help text is displayed before exiting
+  - [ ] Test that both `-h` and `--help` work correctly
+  - [ ] Ensure `--version` also displays properly
+
+### [x] 2.2. Enhance Error Message for Missing Input
+
+- **Issue:** When running `twars-url2md` without arguments, the error message is too brief
+- **Current:** "Error: Either --stdin or --input must be specified\nRun with --help for usage information"
+- **Tasks:**
+  - [x] Update error message to include a brief usage example
+  - [x] Consider showing a condensed help message when no arguments are provided
+  - [x] Make the error message more helpful for first-time users
+
+### [ ] 2.3. Fix URL Processing Stalling Issue
+
+- **Issue:** Processing URLs (e.g., `echo "https://helpx.adobe.com/pl/indesign/using/using-fonts.html" | twars-url2md --stdin`) stalls after printing "Processing URL:" message
+- **Root Cause Analysis:**
+  - The code creates directories but doesn't complete the processing
+  - The monolith processing might be hanging or timing out
+  - No timeout is set for the HTTP requests or monolith processing
+- **Tasks:**
+  - [ ] Add comprehensive timeout handling for HTTP requests
+  - [ ] Add timeout for monolith processing in `spawn_blocking` task
+  - [ ] Add more detailed progress logging to identify where the stall occurs
+  - [ ] Ensure error messages are properly propagated when processing fails
+  - [ ] Test with various URLs to ensure robustness
+  - [x] Refactor `fetch_html` in `src/html.rs` to handle errors from `monolith` gracefully without relying on `std::panic::catch_unwind`. Explore `monolith`'s error reporting capabilities or use it in a way that's less prone to panicking.
+  - [ ] Remove the top-level `panic::set_hook` and `panic::catch_unwind` in `main.rs` if underlying issues are resolved. The goal is for the application to exit cleanly with an error message via `Result` propagation.
+
+### [ ] 2.4. Fix Output Writing Issues
+
+- **Issue:** When using `-p out.md` or `-o out`, no output files are created
+- **Root Cause:** Need to verify the output writing logic in both pack and regular modes
+- **Tasks:**
+  - [ ] Debug why files aren't being written when output options are specified
+  - [ ] Ensure parent directories are created properly
+  - [ ] Add logging to confirm when files are successfully written
+  - [ ] Test all output modes: stdout, single file, directory structure, and pack mode
+  - [ ] Add helper `fn output_mode(path: &Path) -> OutputMode` where `enum OutputMode { Directory(PathBuf), SingleFile(PathBuf) }`.
+  - [ ] In `Cli::create_config` detect `path.extension() == Some("md".as_ref())` ⇒ `SingleFile` else `Directory`.
+  - [ ] Propagate this choice via `Config` (replace the boolean pair `single_file`/`has_output` with `output_kind: OutputKind`).
+  - [ ] Update `lib::process_urls` to:
+     • write each URL into its own file when `Directory`, preserving the current hierarchy logic;
+     • write (append) all Markdown into the single file when `SingleFile`, prefixed with `# {url}` separators (same formatter used by `--pack`).
+  - [ ] Make `--pack` mutually exclusive with single-file mode. Clap can enforce this via `.conflicts_with("output")` when `output` ends in `.md`.
+  - [ ] Ensure parent directories exist for both modes using `tokio::fs::create_dir_all` with error propagation.
+  - [ ] Add extensive logging: `tracing::debug!(%path, "wrote file")` for every successful write; `tracing::error!` for failures.
+  - [ ] Integration tests (`tests/output_modes.rs`) covering:
+       - directory mode (`-o outdir`);
+       - single-file mode (`-o out.md`);
+       - pack mode (`-p combined.md` with multiple URLs);
+       verify file existence and that the first 10 chars of content are non-empty Markdown.
+
+## [ ] 3. Logging Framework Integration
+
+- **Goal:** Replace current `eprintln!`-based verbose/debug logging with a structured logging framework.
+- **Tasks:**
+  - [x] Add `tracing` and `tracing-subscriber` to `Cargo.toml`.
+  - [x] Configure `tracing-subscriber` (e.g., using `fmt` layer and `EnvFilter` for level control via environment variable like `RUST_LOG`).
+  - [x] Initialize the subscriber early in `main()`.
+  - [x] Replace all instances of `eprintln!` used for debugging, verbose output, or warnings with appropriate `tracing` macros (`trace!`, `debug!`, `info!`, `warn!`, `error!`).
+  - [ ] Update `README.md` or provide usage instructions on how to control log levels.
+
+## [ ] 4. Error Handling Refinement
+
+- **Goal:** Standardize error handling using `anyhow` and eliminate panics for recoverable errors.
+- **Tasks:**
+  - [x] Review `src/error.rs`. Decide if the custom `Error` enum provides significant benefits over `anyhow::Error`.
+    - If kept, ensure it implements `std::error::Error` and has clean `From` implementations for `anyhow::Error` and other error types.
+    - If not, remove it and use `anyhow::Error` or `anyhow::Result` directly.
+  - [ ] Systematically replace all `unwrap()`, `expect()`, and potential panicking operations with `?` or `Result::map_err`/`with_context`.
+  - [x] Refactor `fetch_html`
+
+## [ ] 5. Dependency Review and Management
+
+- **Goal:** Ensure dependencies are optimal, up-to-date, and managed effectively.
+- **Tasks:**
+  - [ ] **(Major)** Investigate replacing `openssl` (vendored) with `rustls` for TLS handling in `reqwest`.
+    - Change features for `reqwest` in `Cargo.toml`.
+    - Test thoroughly on all target platforms (Linux, macOS, Windows).
+    - This could simplify cross-compilation and reduce binary size/non-Rust dependencies.
+  - [ ] Re-evaluate `monolith`'s role.
+    - Determine if its full capabilities are necessary or if a lighter HTML fetching/cleaning approach would suffice, potentially reducing complexity and improving robustness.
+    - If kept, ensure its integration is as fault-tolerant as possible.
+  - [ ] Update other dependencies to their latest compatible versions using `cargo update`.
+  - [ ] Run `cargo audit` to check for security vulnerabilities in dependencies and address any findings. This should be added to CI.
+
+## [ ] 6. Code Refactoring and Optimization
+
+- **Goal:** Improve code clarity, reduce duplication, and enhance performance where sensible.
+- **Tasks:**
+  - [x] In `src/html.rs`:
+    - Refactor `process_url_async` and `process_url_with_content` to share common logic and reduce code duplication. One function could call the other or both could call a common internal helper.
+    - Improve the robustness of `fetch_html`, especially the fallback logic if `monolith` processing fails or is bypassed.
+  - [x] In `src/url.rs`:
+    - Review URL extraction functions (`extract_urls_from_text`, `extract_urls_from_html_efficient`, `extract_urls_from_html`) for clarity and potential performance bottlenecks. Consolidate if possible.
+    - Consider moving URL _processing_ logic (like `process_url_with_retry`, `process_url_with_content`) to `src/html.rs` or a new `src/processor.rs` module, keeping `src/url.rs` focused on URL parsing and path generation.
+  - [ ] Review use of `Arc<Mutex<Vec>>` for `packed_content` in `src/lib.rs`. Ensure this is the most efficient way to collect results, especially concerning locking. For collecting results from async tasks, channels (`tokio::sync::mpsc`) might be an alternative, though the current approach might be fine given the context.
+
+## [ ] 7. Enhanced Testing Strategy
+
+- **Goal:** Increase test coverage and improve the reliability of tests.
+- **Tasks:**
+  - [ ] Write more unit tests for:
+    - `src/url.rs`: Edge cases in URL parsing, base URL resolution, local file path detection.
+    - `src/html.rs`: Different HTML structures, error conditions during fetching/processing, content-type handling.
+    - `src/markdown.rs`: Various HTML inputs and their expected Markdown output.
+    - `src/cli.rs`: Argument parsing logic and configuration creation.
+  - [ ] Integrate `mockito` (already a dev-dependency) or `wiremock-rs` to mock HTTP server responses. This will allow testing of `src/html.rs`'s network interaction logic (retries, error handling) reliably without actual network calls.
+  - [ ] Develop integration tests:
+    - These tests should compile the binary and run it as a subprocess.
+    - Test various CLI argument combinations.
+    - Verify file outputs (existence, naming, content) and stdout.
+    - Test with sample input files containing URLs and local paths.
+  - [ ] Set up code coverage reporting using `cargo-tarpaulin` or `grcov`.
+
+## [ ] 8. Build and CI/CD Enhancements
+
+- **Goal:** Make the build process more robust, secure, and informative.
+- **Tasks:**
+  - [ ] Add code coverage reporting (e.g., `cargo-tarpaulin`) to the CI workflow (`.github/workflows/ci.yml`). Upload coverage reports to a service like Codecov or Coveralls, or as a GitHub artifact.
+  - [ ] Add `cargo audit` to the CI workflow to check for vulnerable dependencies.
+  - [ ] Ensure `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` are strictly enforced in CI.
+
+## [ ] 9. Streamline Release Process
+
+- **Goal:** Automate and simplify the steps involved in releasing new versions.
+- **Tasks:**
+  - [ ] Introduce `cargo-release` as a development dependency or recommend its global installation for maintainers.
+  - [ ] Update `README.md` (`Development` → `Publishing` section) with instructions on using `cargo-release` to manage version bumps, tagging, and publishing.
+  - [ ] Evaluate if the GitHub Actions `publish-crate` job can be simplified or triggered more directly by `cargo-release` conventions (e.g., publishing on tag push is already good).
+
+## [ ] 10. Documentation Improvements
+
+- **Goal:** Ensure documentation is comprehensive, up-to-date, and useful for both users and contributors (including AI).
+- **Tasks:**
+  - [ ] Create `AGENTS.md` in the repository root. This file should include:
+    - Guidance on coding style (e.g., "follow `rustfmt` and `clippy` recommendations").
+    - Instructions for running tests, including any specific setup for integration tests.
+    - Key architectural decisions or module responsibilities.
+    - Notes on how to handle dependencies or build issues.
+  - [ ] Review and enhance inline code documentation (Rustdoc comments `///` and `//!`). Focus on public APIs, complex functions, and any non-obvious logic.
+  - [ ] Ensure `README.md` is updated to reflect any changes in CLI options, behavior, or build/contribution process resulting from this modernization effort.
+
+## [ ] 11. Final Review and Submission
+
+- **Goal:** Ensure all changes are correct, well-tested, and meet the project's standards.
+- **Tasks:**
+  - [ ] Perform a full round of testing: `cargo test --all-features`.
+  - [ ] Run linters and formatters: `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`.
+  - [ ] Manually test the CLI with a diverse set of inputs (various URLs, local files, stdin, different output options).
+  - [ ] Review all code changes for correctness, clarity, and adherence to the modernization goals.
+  - [ ] Commit changes with a clear, descriptive message and submit.
+
+This `TODO.md` will serve as a checklist for the modernization effort.
+</file>
+
 <file path="Cargo.toml">
 [package]
 name = "twars-url2md"
@@ -4573,11 +4536,6 @@ version = "^2.10"
 features = []
 
 
-[dependencies.openssl]
-version = "0.10"
-features = ["vendored"]
-
-
 [dependencies.regex]
 version = "1.10"
 default-features = false
@@ -4586,7 +4544,8 @@ features = ["std", "perf-dfa", "unicode-perl"]
 
 [dependencies.reqwest]
 version = "0.12"
-features = ["default-tls", "gzip", "brotli", "deflate"]
+default-features = false
+features = ["rustls-tls-native-roots", "gzip", "brotli", "deflate"]
 
 
 [dependencies.tokio]


### PR DESCRIPTION
Changed the reqwest dependency to use `rustls-tls-native-roots` instead of the default (vendored OpenSSL-backed) TLS backend.

This resolves an issue where fetching certain URLs (e.g., from helpx.adobe.com) would fail with an "error sending request for url" error, likely due to TLS negotiation problems with the previous setup. With Rustls, the connection is established successfully.

Removed the explicit `openssl` dependency as it's no longer required by reqwest with this configuration.

## Summary by Sourcery

Switch Reqwest TLS backend to Rustls and remove the OpenSSL dependency to fix connection errors.

Bug Fixes:
- Resolve TLS negotiation failures when fetching certain URLs by switching to Rustls.

Enhancements:
- Configure Reqwest to disable default TLS features and enable rustls-tls-native-roots.

Chores:
- Remove explicit OpenSSL dependency from Cargo.toml.